### PR TITLE
fix: Lazygit のキーバインドを <C-g> から <leader>g に戻す

### DIFF
--- a/.ansible/roles/neovim/templates/init.vim.j2
+++ b/.ansible/roles/neovim/templates/init.vim.j2
@@ -253,7 +253,7 @@ if status_ok then
     },
     on_open = function(term)
       vim.cmd("startinsert!")
-      vim.api.nvim_buf_set_keymap(term.bufnr, "t", "<C-g>", "<cmd>lua _lazygit_toggle()<CR>", { noremap = true, silent = true })
+      vim.api.nvim_buf_set_keymap(term.bufnr, "t", "<leader>g", "<cmd>lua _lazygit_toggle()<CR>", { noremap = true, silent = true })
     end,
   })
 
@@ -267,7 +267,7 @@ EOF
 " lazygit - Git TUI (toggleterm経由)
 " ============================================
 " 使い方:
-"   <C-g>           : Lazygitを起動
+"   <leader>g       : Lazygitを起動
 "   Lazygit内で:
 "     ?             : ヘルプを表示
 "     q             : 終了
@@ -277,7 +277,7 @@ EOF
 "     p             : プル
 "     [             : 前のタブ
 "     ]             : 次のタブ
-nnoremap <silent> <C-g> :<C-u>lua _lazygit_toggle()<CR>
+nnoremap <silent> <leader>g :<C-u>lua _lazygit_toggle()<CR>
 
 " ============================================
 " diffview.nvim - Diff表示とマージエディタ


### PR DESCRIPTION
## 概要
Claude Code が Ctrl+G をインターセプトするため、Neovim 内で Lazygit が開けなくなっていた問題を修正。キーバインドを `<C-g>` から `<leader>g` に戻す。

## 変更内容
- `.ansible/roles/neovim/templates/init.vim.j2` の Lazygit 関連キーバインド3箇所を `<C-g>` → `<leader>g` に変更

## QA手順
1. `ansible-playbook .ansible/site.yml -i .ansible/inventory --tags "neovim"` を実行
2. Neovim を起動し `<leader>g` で Lazygit が開くことを確認
3. Lazygit 内で `<leader>g` でトグルできることを確認

## 影響範囲
- Neovim の Lazygit キーバインドのみ