### PR TITLE
chore: Claude Code を 2.1.90 にアップデート

### DIFF
--- a/.ansible/roles/claudecode/defaults/main.yml
+++ b/.ansible/roles/claudecode/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Claude Code 設定
 
-claude_code_version: "2.1.87"
+claude_code_version: "2.1.90"
 
 # Claude Code directories
 claudecode_dir:


### PR DESCRIPTION
## 概要
Claude Code のバージョンを 2.1.87 から 2.1.90 にアップデート。

## 変更内容
- `.ansible/roles/claudecode/defaults/main.yml` の `claude_code_version` を `2.1.90` に更新

## QA手順
- [ ] `ansible-playbook .ansible/site.yml -i .ansible/inventory --tags claudecode` を実行し、Claude Code が 2.1.90 にアップデートされることを確認

## 影響範囲
- claudecode ロールのみ