### PR TITLE
chore: Claude Code 2.1.100 へ更新 & マイグレーション実行ルール追加

### DIFF
--- a/.ansible/roles/claudecode/defaults/main.yml
+++ b/.ansible/roles/claudecode/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Claude Code 設定
 
-claude_code_version: "2.1.90"
+claude_code_version: "2.1.100"
 
 # Claude Code directories
 claudecode_dir:

--- a/.ansible/roles/claudecode/files/claude-rules/ruby-python.md
+++ b/.ansible/roles/claudecode/files/claude-rules/ruby-python.md
@@ -20,3 +20,8 @@ paths:
 - `rails-security-auditor` でセキュリティチェック
 - `db/migrate/` 変更時は `rails-db-migration-reviewer` で安全性確認
 - `spec/` 変更時は `rails-test-guardian` でテスト実行
+
+## Rails マイグレーション実行ルール
+- `db/migrate/` にファイルを作成・編集した場合、**必ず `bin/rails db:migrate` を実行する**
+- 実行後、`db/schema.rb`（または `db/structure.sql`）の差分が生成されていることを確認する
+- マイグレーションが失敗した場合は、原因を調査してから修正する


### PR DESCRIPTION
## 概要
Claude Code のバージョン更新と、Rails マイグレーション実行忘れ防止ルールの追加。

## 変更内容
- Claude Code バージョンを 2.1.87 → 2.1.100 に更新
- `ruby-python.md` ルールに「マイグレーションファイル作成時は `db:migrate` を実行する」ルールを追加

## QA手順
- `ansible-playbook .ansible/site.yml -i .ansible/inventory --tags "claudecode"` を実行し、設定が反映されることを確認