### PR TITLE
chore: ステータスラインにリセット残り時間を表示

### DIFF
--- a/.ansible/roles/claudecode/files/statusline.sh
+++ b/.ansible/roles/claudecode/files/statusline.sh
@@ -7,7 +7,9 @@ PCT=$(echo "$input" | jq -r '.context_window.used_percentage // 0' | cut -d. -f1
 COST=$(echo "$input" | jq -r '.cost.total_cost_usd // 0')
 DURATION_MS=$(echo "$input" | jq -r '.cost.total_duration_ms // 0')
 FIVE_H=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
+FIVE_H_RESET=$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // empty')
 WEEK=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
+WEEK_RESET=$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // empty')
 
 PCT=${PCT:-0}; COST=${COST:-0}; DURATION_MS=${DURATION_MS:-0}
 [ "$PCT" -gt 100 ] && PCT=100
@@ -29,8 +31,31 @@ COST_FMT=$(printf '$%.2f' "$COST")
 MINS=$((DURATION_MS / 60000))
 SECS=$(((DURATION_MS % 60000) / 1000))
 
+fmt_remaining() {
+  local resets_at=$1 now remaining
+  [ -z "$resets_at" ] && return
+  now=$(date +%s)
+  remaining=$((resets_at - now))
+  [ "$remaining" -le 0 ] && echo "0m" && return
+  local days=$((remaining / 86400))
+  local hours=$(( (remaining % 86400) / 3600 ))
+  local mins=$(( (remaining % 3600) / 60 ))
+  if [ "$days" -gt 0 ]; then echo "${days}d${hours}h"
+  elif [ "$hours" -gt 0 ]; then echo "${hours}h${mins}m"
+  else echo "${mins}m"
+  fi
+}
+
 LIMITS=""
-[ -n "$FIVE_H" ] && LIMITS=" | 5h: $(printf '%.0f' "$FIVE_H")%"
-[ -n "$WEEK" ] && LIMITS="${LIMITS} 7d: $(printf '%.0f' "$WEEK")%"
+if [ -n "$FIVE_H" ]; then
+  FIVE_H_REM=$(fmt_remaining "$FIVE_H_RESET")
+  LIMITS=" | 5h: $(printf '%.0f' "$FIVE_H")%"
+  [ -n "$FIVE_H_REM" ] && LIMITS="${LIMITS}(${FIVE_H_REM})"
+fi
+if [ -n "$WEEK" ]; then
+  WEEK_REM=$(fmt_remaining "$WEEK_RESET")
+  LIMITS="${LIMITS} 7d: $(printf '%.0f' "$WEEK")%"
+  [ -n "$WEEK_REM" ] && LIMITS="${LIMITS}(${WEEK_REM})"
+fi
 
 printf '%b\n' "${CYAN}[${MODEL}]${RESET} ${BAR_COLOR}${BAR}${RESET} ${PCT}% | ${YELLOW}${COST_FMT}${RESET} | ${MINS}m ${SECS}s${LIMITS}"


### PR DESCRIPTION
## 概要
ステータスラインのレート制限表示に、リセットまでの残り時間を追加。

## 変更内容
- `statusline.sh` に `resets_at` フィールドの解析と残り時間計算ロジックを追加
- 表示例: `5h: 23%(2h30m) 7d: 41%(3d5h)`

## QA手順
1. `ansible-playbook .ansible/site.yml -i .ansible/inventory --tags claudecode` を実行
2. Claude Code を起動してステータスラインにリセット残り時間が表示されることを確認

## 影響範囲
- Claude Code のステータスライン表示のみ