### PR TITLE
fix: defaultMode を permissions 配下に移動して acceptEdits を有効化

### DIFF
--- a/.ansible/roles/claudecode/templates/settings.json.j2
+++ b/.ansible/roles/claudecode/templates/settings.json.j2
@@ -1,12 +1,11 @@
 {
   "enableAllProjectMcpServers": true,
   "permissions": {
+    "defaultMode": "acceptEdits",
     "allow": [
       "Read",
       "Write(**)",
-      "Write(config/locales/**)",
       "Edit(**)",
-      "Edit(config/locales/**)",
       "Glob(**)",
       "Grep(**)",
       "Bash",
@@ -84,7 +83,6 @@
   },
   "voiceEnabled": true,
   "language": "Japanese",
-  "defaultMode": "acceptEdits",
   "env": {
     "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
     "ENABLE_LSP_TOOL": "1",


### PR DESCRIPTION
## 概要
Claude Code の `settings.json` テンプレートで `defaultMode: "acceptEdits"` がトップレベルに置かれていたため、acceptEdits モードが機能せず、Edit/Write/Grep などのツール実行毎に確認ダイアログが出ていた。公式仕様 (`permissions.defaultMode`) に沿って正しい位置へ移動する。

## 変更内容
- `defaultMode: "acceptEdits"` を JSON ルート → `permissions` 配下に移動
- `permissions.allow` の重複エントリを削除
  - `Write(config/locales/**)` を削除（`Write(**)` で包含されるため）
  - `Edit(config/locales/**)` を削除（`Edit(**)` で包含されるため）

## QA手順
1. `ansible-playbook .ansible/site.yml -i .ansible/inventory --tags claudecode` を実行
2. `~/.claude/settings.json` を開き、以下を確認:
   - `permissions.defaultMode` が `"acceptEdits"` になっている
   - JSON ルート直下に `defaultMode` が存在しない
3. 新しい Claude Code セッションを起動し、ファイル編集（Edit/Write）や Grep 実行時に yes/no 確認ダイアログが出ないことを確認

## 影響範囲
- 個人の macOS/WSL ローカル環境にデプロイされる Claude Code の `settings.json` のみ
- 他ロール・他 Playbook への影響なし