### PR TITLE
chore: Claude Code の通知フックを Stop 1本に集約

### DIFF
--- a/.ansible/roles/claudecode/templates/settings.json.j2
+++ b/.ansible/roles/claudecode/templates/settings.json.j2
@@ -54,24 +54,9 @@
           {
             "type": "command",
 {% if ansible_distribution == 'MacOSX' %}
-            "command": "terminal-notifier -title 'Claude Code' -message '処理が完了しました' -sound Ping"
+            "command": "terminal-notifier -title 'Claude Code' -message '入力待ちです' -sound Ping"
 {% else %}
-            "command": "notify-send 'Claude Code' '処理が完了しました'"
-{% endif %}
-          }
-        ]
-      }
-    ],
-    "PostToolUse": [
-      {
-        "matcher": "Write|Edit|MultiEdit",
-        "hooks": [
-          {
-            "type": "command",
-{% if ansible_distribution == 'MacOSX' %}
-            "command": "terminal-notifier -title 'Claude Code' -message ' 入力待ちです' -sound Ping"
-{% else %}
-            "command": "notify-send 'Claude Code' ' 入力待ちです'"
+            "command": "notify-send 'Claude Code' '入力待ちです'"
 {% endif %}
           }
         ]


### PR DESCRIPTION
## 概要
Claude Code の通知フックを最適化する。Edit/Write のたびに `PostToolUse` フックで「入力待ちです」通知が鳴っていたが、実際は入力待ちではなく紛らわしく・冗長だったため、通知を `Stop` フック1本に集約する。

## 変更内容
- `hooks.PostToolUse` セクション全体を削除（Write|Edit|MultiEdit 毎の通知をやめる）
- `hooks.Stop` のメッセージを `'処理が完了しました'` → `'入力待ちです'` に変更
  - これにより「通知が鳴る = 入力待ち」のシンプルな対応関係になる
  - ついでに元メッセージ先頭の半角スペース誤字も解消

## QA手順
1. `ansible-playbook .ansible/site.yml -i .ansible/inventory --tags claudecode` を実行
2. `~/.claude/settings.json` を開き、以下を確認:
   - `hooks.Stop` のメッセージが `'入力待ちです'` になっている
   - `hooks.PostToolUse` が存在しない
3. 新しい Claude Code セッションを起動し、以下を確認:
   - Edit/Write のたびには通知が鳴らない
   - 処理完了時（入力待ち状態になった時）に1回だけ「入力待ちです」通知が鳴る

## 影響範囲
- 個人の macOS/WSL ローカル環境にデプロイされる Claude Code の `settings.json` のみ
- `terminal-notifier` / `notify-send` の依存関係に変更なし
- 他ロール・他 Playbook への影響なし