### PR TITLE
chore: Claude Code を 2.1.105 に更新

### DIFF
--- a/.ansible/roles/claudecode/defaults/main.yml
+++ b/.ansible/roles/claudecode/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Claude Code 設定
 
-claude_code_version: "2.1.100"
+claude_code_version: "2.1.105"
 
 # Claude Code directories
 claudecode_dir:


### PR DESCRIPTION
## 概要
Claude Code Native のバージョンを 2.1.100 から 2.1.105 へ更新する。

## 変更内容
- `.ansible/roles/claudecode/defaults/main.yml` の `claude_code_version` を `"2.1.100"` → `"2.1.105"`

## QA手順
1. `ansible-playbook .ansible/site.yml -i .ansible/inventory --tags claudecode` を実行
2. `claude --version` が `2.1.105` を返すことを確認
3. 新しい Claude Code セッションで通常のコード編集・Bash 実行が問題なく動くことを確認

## 影響範囲
- 個人の macOS/WSL ローカル環境にインストールされる Claude Code バイナリ
- 既存 `~/.claude/settings.json` のスキーマ互換性に変更なし