### PR TITLE
chore: Opus 4.6 の 1M context 自動アップグレードを無効化

### DIFF
--- a/.ansible/roles/claudecode/templates/settings.json.j2
+++ b/.ansible/roles/claudecode/templates/settings.json.j2
@@ -70,6 +70,7 @@
   "language": "Japanese",
   "env": {
     "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+    "CLAUDE_CODE_DISABLE_1M_CONTEXT": "1",
     "ENABLE_LSP_TOOL": "1",
     "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION": "false",
     "CLAUDE_CODE_SUBAGENT_MODEL": "claude-sonnet-4-6"{% if claude_code_experimental_features.agent_teams %},


### PR DESCRIPTION
## 概要
Max/Team プランで Opus 4.6 が自動的に 1M context にアップグレードされる挙動を無効化し、200K context に固定してトークン消費 (料金 2x) を抑える。

通常のコード修正タスクは 200K context で十分カバーでき、溢れそうになったら auto-compact が履歴を圧縮してくれる。巨大ログ解析などの特殊タスクで 1M を使いたくなった時は、その時だけ env を外せば戻せる。

## 変更内容
- `.ansible/roles/claudecode/templates/settings.json.j2` の `env` セクションに `"CLAUDE_CODE_DISABLE_1M_CONTEXT": "1"` を追加

## QA手順
1. `ansible-playbook .ansible/site.yml -i .ansible/inventory --tags claudecode` を実行
2. `~/.claude/settings.json` の `env.CLAUDE_CODE_DISABLE_1M_CONTEXT` が `"1"` になっていることを確認
3. 新しい Claude Code セッションを起動し、モデル表示またはトークン消費を従来と比較して抑制されていることを確認

## 影響範囲
- 個人の macOS/WSL ローカル環境にデプロイされる Claude Code の `settings.json` のみ
- コンテキストウィンドウが 1M → 200K に制限されるため、巨大ファイルの一括解析や非常に長い会話は auto-compact が走る（運用上の影響は軽微）

## 参考
- [Claude Code model config](https://code.claude.com/docs/en/model-config.md)