### PR TITLE
refactor: tmux から claude を直接起動して neovim 経由を撤去

### DIFF
--- a/.ansible/roles/neovim/defaults/main.yml
+++ b/.ansible/roles/neovim/defaults/main.yml
@@ -38,9 +38,7 @@ neovim_plugins:
     version: "f8d8d872bb319f640d5177dad5fbf01f7a16d7d0"
   - name: "zbirenbaum/copilot-cmp"
     version: "b6e5286b3d74b04256d0a7e3bd2908eabec34b44"
-  # claude code
-  - name: "greggh/claude-code.nvim"
-    version: "55c0cb59828fbc3bec744288286a46f5d5750b83"
+  # neo-tree.nvim の依存
   - name: "nvim-lua/plenary.nvim"
     version: "857c5ac632080dba10aae49dba902ce3abf91b35"
   # codex

--- a/.ansible/roles/neovim/tasks/main.yml
+++ b/.ansible/roles/neovim/tasks/main.yml
@@ -75,6 +75,12 @@
     path: "{{ neovim_plugin_path }}/fzf-preview.vim"
     state: absent
 
+# TODO: 全マシンへの適用完了後に削除する（claude-code.nvim → tmux 直接起動に移行）
+- name: remove old claude-code plugin
+  ansible.builtin.file:
+    path: "{{ neovim_plugin_path }}/claude-code.nvim"
+    state: absent
+
 - name: install neovim plugin
   ansible.builtin.git:
     repo: "https://github.com/{{ item.name }}.git"

--- a/.ansible/roles/neovim/templates/init.vim.j2
+++ b/.ansible/roles/neovim/templates/init.vim.j2
@@ -104,11 +104,7 @@ if bufferline_ok then
 
       -- ターミナルバッファの場合
       if buftype == 'terminal' then
-        if bufname:match('claude') then
-          return 'Claude Code'
-        else
-          return 'Terminal'
-        end
+        return 'Terminal'
       end
 
       -- 空のバッファ
@@ -312,10 +308,6 @@ nnoremap <silent> <leader>df :<C-u>DiffviewOpen<CR>
 tnoremap jk <C-\><C-n>
 command! -nargs=* T split | wincmd j | resize 20 | terminal <args>
 autocmd TermOpen * startinsert
-
-" Claude Codeターミナルでは行番号・サインカラムを非表示にする
-autocmd TermOpen *claude* setlocal nonumber norelativenumber signcolumn=no
-autocmd BufEnter *claude* setlocal nonumber norelativenumber signcolumn=no
 
 " ============================================
 " fzf-lua - ファジーファインダー
@@ -692,58 +684,6 @@ lua <<EOF
   })
 
   -- ============================================
-  -- Claude Code 設定
-  -- ============================================
-  -- 使い方:
-  --   <Ctrl-,>        : Claude Codeをトグル（ノーマルモード/ターミナルモード）
-  --   <leader>cC      : Claude Code --continue で再開
-  --   <leader>cV      : Claude Code --verbose で起動
-  --   <Ctrl-h/j/k/l>  : ウィンドウ間の移動
-  --   <Ctrl-f/b>      : ページアップ/ダウン
-  local status_ok, claude_code = pcall(require, "claude-code")
-  if status_ok then
-    claude_code.setup({
-      window = {
-        split_ratio = 1.0,
-        position = "botright",
-        enter_insert = false,
-        start_in_normal_mode = true,
-        hide_numbers = true,
-        hide_signcolumn = true,
-        hide_cursorline = true,
-      },
-      refresh = {
-        enable = true,
-        updatetime = 100,
-        timer_interval = 1000,
-        show_notifications = true,
-      },
-      git = {
-        use_git_root = true,
-        multi_instance = false,
-      },
-      command = "claude",
-      command_variants = {
-        continue = "--continue",
-        resume = "--resume",
-        verbose = "--verbose",
-      },
-      keymaps = {
-        toggle = {
-          normal = "<C-,>",
-          terminal = "<C-,>",
-          variants = {
-            continue = "<leader>cC",
-            verbose = "<leader>cV",
-          },
-        },
-        window_navigation = true,
-        scrolling = true,
-      }
-    })
-  end
-
-  -- ============================================
   -- Go言語専用設定
   -- ============================================
   -- goimports: import文を自動整理する関数
@@ -843,57 +783,3 @@ if system('uname -a | grep microsoft') != ''
   noremap <silent> p :call setreg('"',system('win32yank.exe -o'))<CR>""p
 endif
 
-" ============================================
-" 起動時の自動設定
-" ============================================
-" 引数なしで起動した場合に自動でタブを開く
-augroup StartupTabs
-  au!
-  autocmd VimEnter * nested call timer_start(500, {-> s:startup_tabs()})
-augroup END
-
-function! s:startup_tabs()
-  " 引数なしで起動したかどうかを判定
-  " - ファイル引数がある場合は開かない (argc() > 0)
-  " - コマンド引数(-c)がある場合は開かない
-  " - git commit等で呼ばれた場合は開かない
-  let l:should_open_tabs = argc() == 0 && !s:has_command_arg()
-
-  " 引数なしの場合のみタブを開く
-  if l:should_open_tabs
-    " ClaudeCodeを起動（プラグインが完全に読み込まれるまで待つ）
-    if exists(':ClaudeCode')
-      " 起動時の[No Name]バッファを先に削除
-      if bufname('%') == '' && !&modified
-        enew
-      endif
-      ClaudeCode
-    else
-      " プラグインがまだロードされていない場合は、さらに待つ
-      call timer_start(500, {-> s:retry_claude_toggle()})
-    endif
-
-    " 別タブでcommon.sqlを開く
-    tabnew ~/.local/share/nvim/common.sql
-
-    " 最初のタブ（ClaudeCode）に戻る
-    tabfirst
-  endif
-endfunction
-
-" コマンド引数(-cなど)が指定されているかチェック
-function! s:has_command_arg()
-  for arg in v:argv
-    if arg =~# '^-c' || arg =~# '^+' || arg =~# '^--cmd'
-      return 1
-    endif
-  endfor
-  return 0
-endfunction
-
-function! s:retry_claude_toggle()
-  if exists(':ClaudeCode')
-    tabfirst
-    ClaudeCode
-  endif
-endfunction

--- a/.ansible/roles/tmux/defaults/main.yml
+++ b/.ansible/roles/tmux/defaults/main.yml
@@ -11,6 +11,12 @@ brew_pkg:
 # tmux バージョン ( master の最新コミットを指定 )
 tmux_version: "11e69f6025f5783fe17d43247de1c3f659a19b69"
 tmux_main_dir: "~/"
-tmux_sub_dir:
-  - "~/src"
+# tmux セッション起動時に開く window を定義する
+# - dir: tmux の -c で指定する作業ディレクトリ（必須）
+# - command: 起動時に send-keys で送信するコマンド文字列（任意）
+# 注意: command にダブルクォートや特殊文字を含めると生成される .tmux.conf を破損させる可能性があるため避けること
+tmux_windows:
+  - dir: "~/"
+    command: "nvim ~/.local/share/nvim/common.sql"
+  - dir: "~/src"
 

--- a/.ansible/roles/tmux/tasks/main.yml
+++ b/.ansible/roles/tmux/tasks/main.yml
@@ -60,10 +60,3 @@
     dest: "~/.tmux.conf"
     mode: 0644
 
-- name: edit ~/.tmux.conf
-  ansible.builtin.lineinfile:
-    dest: ~/.tmux.conf
-    line: "new-window -c {{ item }}"
-  with_items:
-    - "{{ tmux_sub_dir }}"
-

--- a/.ansible/roles/tmux/templates/.tmux.conf.j2
+++ b/.ansible/roles/tmux/templates/.tmux.conf.j2
@@ -63,4 +63,11 @@ if-shell "uname -a | grep -q microsoft" "bind-key -T copy-mode-vi Enter send -X 
 
 # デフォルトで開くセッションの設定
 new-session -d -s default -c {{ tmux_main_dir }}
-send-keys -t default "nvim" C-m
+send-keys -t default "claude" C-m
+
+{% for window in tmux_windows %}
+new-window -c {{ window.dir }}
+{% if window.command is defined and window.command %}
+send-keys "{{ window.command }}" C-m
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
## 概要
tmux 起動時に Neovim 経由で Claude Code を立ち上げる構成をやめ、tmux から `claude` を直接起動するように変更する。`greggh/claude-code.nvim` の resume 不動作問題や埋め込みターミナルの表示崩れ・コピペ不便を根本解決する。

## 変更内容
- `tmux_sub_dir` 変数を `tmux_windows`（`dir` + 任意の `command`）に置き換え、`.tmux.conf.j2` の Jinja2 ループで展開するように変更
- `tasks/main.yml` から不要になった `lineinfile` タスクを削除（テンプレートに一本化、冪等性も改善）
- `.tmux.conf.j2` のデフォルトセッション起動を `nvim` から `claude` に変更
- `greggh/claude-code.nvim` プラグインとその関連コードを削除
  - `defaults/main.yml` のプラグインエントリ
  - `init.vim.j2` の `claude-code` setup ブロック・キーマップ
  - Claude Code バッファ用 `autocmd TermOpen/BufEnter *claude*`
  - bufferline のタブ名判定内 `bufname:match('claude')` 分岐
  - 起動時自動タブ機構（`StartupTabs` augroup、`s:startup_tabs`/`s:has_command_arg`/`s:retry_claude_toggle` 関数）
- 既存マシン向けに `claude-code.nvim` ディレクトリを削除する cleanup タスクを追加
- `plenary.nvim` は `neo-tree.nvim` の依存のため残置

## QA手順
1. ブランチを checkout して `ansible-playbook .ansible/site.yml -i .ansible/inventory --tags "tmux,neovim"` を実行
2. 新しい tmux セッション（`tmux kill-server && tmux`）を起動して以下を確認
   - window 0 で `claude` が直接起動する
   - window 1 で `nvim ~/.local/share/nvim/common.sql` が開かれている
   - window 2 が `~/src` をカレントディレクトリにして起動している
3. Claude Code 内で `/resume` を叩いて過去セッション一覧が表示されることを確認
4. `nvim` を単独起動した際にエラーが出ず、`[No Name]` バッファで普通に立ち上がることを確認
5. 既存マシンでは `~/.local/share/nvim/site/pack/plugins/start/claude-code.nvim` が削除されていることを確認

## 影響範囲
- macOS / WSL 両環境の tmux 起動時の見た目
- Neovim の起動時の動作（`ClaudeCode` / `common.sql` タブが自動で開かなくなる）
- 既存のキーバインド `<Ctrl-,>` / `<leader>cC` / `<leader>cV` が使えなくなる