### PR TITLE
fix: tmux の common.sql window を ~/.local/share/nvim で開く

### DIFF
--- a/.ansible/roles/tmux/defaults/main.yml
+++ b/.ansible/roles/tmux/defaults/main.yml
@@ -16,7 +16,7 @@ tmux_main_dir: "~/"
 # - command: 起動時に send-keys で送信するコマンド文字列（任意）
 # 注意: command にダブルクォートや特殊文字を含めると生成される .tmux.conf を破損させる可能性があるため避けること
 tmux_windows:
-  - dir: "~/"
+  - dir: "~/.local/share/nvim"
     command: "nvim ~/.local/share/nvim/common.sql"
   - dir: "~/src"
 


### PR DESCRIPTION
## 概要
tmux デフォルト起動時の 1 つ目 window の作業ディレクトリを、用途がわかる場所に変更する。

## 変更内容
- `.ansible/roles/tmux/defaults/main.yml` の `tmux_windows[0].dir` を `~/` → `~/.local/share/nvim` に変更
- 1 つ目の window は `nvim ~/.local/share/nvim/common.sql` を開くためのもの。`.tmux.conf.j2` の `automatic-rename-format '#{b:pane_current_path}'` により window 名はカレントディレクトリの basename になるため、`~/` だとホームディレクトリ名が表示されていた。`~/.local/share/nvim` にすれば window 名が `nvim` になり用途が一目でわかる

## QA手順
1. 本 PR の変更を適用: `ansible-playbook .ansible/site.yml -i .ansible/inventory --tags tmux`
2. 新しいターミナルで tmux を起動（`.bash_profile` 経由で自動起動する想定）
3. 1 つ目の window 名が `nvim` になっていることを確認
4. その window で `nvim ~/.local/share/nvim/common.sql` が開かれていることを確認
5. 2 つ目の window が `~/src` で開かれていることを確認（既存挙動の維持）

## 影響範囲
- tmux の起動時 window レイアウトのみ。キーバインドや他 window の挙動には影響なし