### PR TITLE
fix: LSP plugins を custom-lsp marketplace に統一してトークン消費を削減

### DIFF
--- a/.ansible/roles/claudecode/defaults/main.yml
+++ b/.ansible/roles/claudecode/defaults/main.yml
@@ -23,16 +23,9 @@ claudecode_dir:
 claude_code_plugins:
   - claude-md-management
 
-# Claude Code LSP plugins
-# https://github.com/anthropics/claude-plugins-official
-claude_code_lsp_plugins:
-  - typescript-lsp
-  - gopls-lsp
-  - rust-analyzer-lsp
-
 # Custom LSP plugins (via custom-lsp marketplace)
-# pylsp-lsp は Python環境の問題があるため無効化
-# LSPが必要な場合は Claude Code 標準のLSP機能 (ENABLE_LSP_TOOL=1) を使用
+# claude-plugins-official の LSP プラグインは .lsp.json 未同梱のため使用しない
+# LSP サーバーはすべて custom-lsp マーケットプレイス経由で管理する
 claude_code_custom_lsp_plugins:
   - name: solargraph-lsp
     description: "Ruby Language Server (Solargraph)"
@@ -43,6 +36,32 @@ claude_code_custom_lsp_plugins:
       ".rb": ruby
       ".rake": ruby
       ".gemspec": ruby
+  - name: typescript-lsp
+    description: "TypeScript/JavaScript Language Server"
+    command: typescript-language-server
+    args:
+      - --stdio
+    extensions:
+      ".ts": typescript
+      ".tsx": typescriptreact
+      ".js": javascript
+      ".jsx": javascriptreact
+      ".mts": typescript
+      ".cts": typescript
+      ".mjs": javascript
+      ".cjs": javascript
+  - name: gopls-lsp
+    description: "Go Language Server (gopls)"
+    command: gopls
+    args: []
+    extensions:
+      ".go": go
+  - name: rust-analyzer-lsp
+    description: "Rust Language Server (rust-analyzer)"
+    command: rust-analyzer
+    args: []
+    extensions:
+      ".rs": rust
 
 # Claude Code external marketplace plugins
 # format: { marketplace: "github-owner/repo", alias: "marketplace-name", plugins: ["plugin-name"] }

--- a/.ansible/roles/claudecode/tasks/main.yml
+++ b/.ansible/roles/claudecode/tasks/main.yml
@@ -202,11 +202,18 @@
   failed_when: false
   when: claude_plugin_check.rc == 0
 
-- name: install Claude Code LSP plugins from official marketplace
-  ansible.builtin.command: "claude plugin install {{ item }}"
-  loop: "{{ claude_code_lsp_plugins }}"
-  register: plugin_install_result
-  changed_when: "'Successfully installed' in plugin_install_result.stdout"
+# ============================================
+# Claude Code LSP Plugin Setup
+# ============================================
+# LSP plugins from claude-plugins-official ship without .lsp.json and do nothing
+- name: uninstall dummy LSP plugins from official marketplace
+  ansible.builtin.command: "claude plugin uninstall {{ item }}@claude-plugins-official"
+  loop:
+    - typescript-lsp
+    - gopls-lsp
+    - rust-analyzer-lsp
+  register: dummy_uninstall_result
+  changed_when: false  # loop+register: per-iteration stdout not accessible; cleanup task, changed tracking not needed
   failed_when: false
   when: claude_plugin_check.rc == 0
 
@@ -220,11 +227,32 @@
     - ".claude-plugin"
     - "plugins"
 
-- name: create custom LSP plugin source directories
+- name: create custom LSP plugin source directories (root)
   ansible.builtin.file:
     path: "{{ ansible_env.HOME }}/.claude/plugins/custom-marketplace/plugins/{{ item.name }}"
     state: directory
     mode: 0755
+  loop: "{{ claude_code_custom_lsp_plugins }}"
+
+- name: create .claude-plugin subdirectory for custom LSP plugins
+  ansible.builtin.file:
+    path: "{{ ansible_env.HOME }}/.claude/plugins/custom-marketplace/plugins/{{ item.name }}/.claude-plugin"
+    state: directory
+    mode: 0755
+  loop: "{{ claude_code_custom_lsp_plugins }}"
+
+- name: deploy plugin.json for custom LSP plugins
+  ansible.builtin.template:
+    src: "lsp_plugin_manifest.json.j2"
+    dest: "{{ ansible_env.HOME }}/.claude/plugins/custom-marketplace/plugins/{{ item.name }}/.claude-plugin/plugin.json"
+    mode: 0644
+  loop: "{{ claude_code_custom_lsp_plugins }}"
+
+- name: deploy .lsp.json for custom LSP plugins
+  ansible.builtin.template:
+    src: "lsp_plugin_lsp.json.j2"
+    dest: "{{ ansible_env.HOME }}/.claude/plugins/custom-marketplace/plugins/{{ item.name }}/.lsp.json"
+    mode: 0644
   loop: "{{ claude_code_custom_lsp_plugins }}"
 
 - name: create README for custom LSP plugins

--- a/.ansible/roles/claudecode/templates/lsp_plugin_lsp.json.j2
+++ b/.ansible/roles/claudecode/templates/lsp_plugin_lsp.json.j2
@@ -1,0 +1,7 @@
+{
+  "{{ item.name | replace('-lsp', '') }}": {
+    "command": "{{ item.command }}",
+    "args": {{ item.args | to_json }},
+    "extensionToLanguage": {{ item.extensions | to_json }}
+  }
+}

--- a/.ansible/roles/claudecode/templates/lsp_plugin_manifest.json.j2
+++ b/.ansible/roles/claudecode/templates/lsp_plugin_manifest.json.j2
@@ -1,0 +1,5 @@
+{
+  "name": "{{ item.name }}",
+  "version": "1.0.0",
+  "description": "{{ item.description }}"
+}


### PR DESCRIPTION
## 概要

Claude Code の LSP が TypeScript/Go/Rust で実質機能していなかった問題を修正。
`claude-plugins-official` の LSP プラグインは `.lsp.json` を同梱しておらず、README だけの空プラグインだったため、custom-lsp マーケットプレイス経由の自前プラグインに統一する。

トークン消費削減が目的。LSP が効いていないと TS/Go/Rust のファイル調査が全文 Read に頼るため、セッションあたり数万トークン単位で無駄が発生していた。

## 変更内容

- `defaults/main.yml`: `claude_code_lsp_plugins`（ダミー変数）を削除し、`claude_code_custom_lsp_plugins` に typescript-lsp / gopls-lsp / rust-analyzer-lsp を追加
- `tasks/main.yml`:
  - ダミープラグイン（@claude-plugins-official 版）の uninstall タスクを追加
  - プラグインソースディレクトリに `.claude-plugin/` サブディレクトリ作成タスクを追加
  - `.lsp.json` と `.claude-plugin/plugin.json` を templates/ 経由で自動生成するタスクを追加
- `templates/lsp_plugin_lsp.json.j2` (新規): `.lsp.json` 生成テンプレート
- `templates/lsp_plugin_manifest.json.j2` (新規): `.claude-plugin/plugin.json` 生成テンプレート

## QA 手順

1. `ansible-playbook .ansible/site.yml -i .ansible/inventory --tags claudecode` を実行
2. `ls ~/.claude/plugins/cache/custom-lsp/` に typescript-lsp / gopls-lsp / rust-analyzer-lsp が並ぶことを確認
3. 各プラグインディレクトリ配下に `.lsp.json` が配置されていることを確認
4. Claude Code を新しいセッションで起動し、TypeScript/Go ファイルで symbol lookup が効くことを確認

## 影響範囲

Claude Code の LSP 起動設定のみ。他のロール・他のツールへの影響なし。