### PR TITLE
chore: 未使用の memory MCP サーバーを削除

### DIFF
--- a/.ansible/roles/claudecode/templates/mcpServers.json.j2
+++ b/.ansible/roles/claudecode/templates/mcpServers.json.j2
@@ -11,13 +11,6 @@
     "type": "stdio",
     "args": ["-y", "@upstash/context7-mcp@latest"]
   },
-  "memory": {
-    "command": "{{ ansible_env.HOME }}/.local/share/mise/installs/node/{{ node_version }}/bin/npx",
-    "args": [
-      "-y",
-      "@modelcontextprotocol/server-memory"
-    ]
-  },
   "notion": {
     "type": "http",
     "url": "https://mcp.notion.com/mcp"


### PR DESCRIPTION
## 概要

Ansible 管理下の MCP サーバーから未使用の `memory` を削除する。直近 100 セッションで使用実績ゼロ、かつ Claude Code の auto-memory 機能と役割が重複しているため。

トークン消費削減が目的（LSP 修正 #115 と同じ文脈、別 PR）。

## 変更内容

- `.ansible/roles/claudecode/templates/mcpServers.json.j2` から `memory` ブロック（7行）を削除

## QA 手順

1. `ansible-playbook .ansible/site.yml -i .ansible/inventory --tags claudecode` を実行
2. `claude mcp list` で `memory` が表示されないことを確認
3. Claude Code の新規セッションで deferred tools に `mcp__memory__*` が出ないことを確認

## 影響範囲

`memory` MCP ツール（`mcp__memory__*`）が使用不能になるが、直近 100 セッションで使用実績ゼロのため影響なし。