### PR TITLE
chore: claude code バージョンを 2.1.105 → 2.1.114 に更新

### DIFF
--- a/.ansible/roles/claudecode/defaults/main.yml
+++ b/.ansible/roles/claudecode/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Claude Code 設定
 
-claude_code_version: "2.1.105"
+claude_code_version: "2.1.114"
 
 # Claude Code directories
 claudecode_dir:


### PR DESCRIPTION
## 概要
Claude Code のバージョンを 2.1.105 → 2.1.114 に更新

## 変更内容
- `.ansible/roles/claudecode/defaults/main.yml` の `claude_code_version` を `2.1.114` に更新

## QA手順
- Ansible playbook を実行し、Claude Code が 2.1.114 にアップグレードされることを確認
- `claude --version` で `2.1.114` が表示されること

## 影響範囲
- Claude Code のインストールバージョンのみ