### PR TITLE
common.sql を開く sql alias を追加

### DIFF
--- a/.ansible/roles/common/files/.bashrc
+++ b/.ansible/roles/common/files/.bashrc
@@ -30,6 +30,7 @@ alias ll='ls -laF'
 # vim/nvim
 ###############
 alias vim='nvim'
+alias sql='nvim ~/.local/share/nvim/common.sql'
 
 #####################
 # uv (Python package manager)


### PR DESCRIPTION
## 概要
`~/.local/share/nvim/common.sql` のパスを覚えていなくても sql 用スクラッチをすぐ開けるよう、共通 .bashrc に alias を追加する。

## 変更内容
- `.ansible/roles/common/files/.bashrc` に `alias sql='nvim ~/.local/share/nvim/common.sql'` を追加

## QA手順
1. ansible 適用後、新しい bash セッションを開く
2. `sql` を実行 → nvim で `~/.local/share/nvim/common.sql` が開けば OK

## 影響範囲
- common ロールが当たる端末の bash alias のみ。`sql` という名前のコマンドは未使用なので衝突なし。