### PR TITLE
fix: mise global ツール管理を config.toml テンプレートに統合

### DIFF
--- a/.ansible/roles/mise/tasks/main.yml
+++ b/.ansible/roles/mise/tasks/main.yml
@@ -8,55 +8,23 @@
   ansible.builtin.shell: "curl -fsSL https://mise.run | sh"
   when: not mise_installed.stat.exists
 
-- name: check installed node version
-  ansible.builtin.shell: "{{ mise_bin }} list node | grep {{ node_version }}"
-  register: check_installed_node
-  failed_when: false
-  changed_when: false
+- name: ensure mise config directory exists
+  ansible.builtin.file:
+    path: "{{ ansible_env.HOME }}/.config/mise"
+    state: directory
+    mode: "0755"
 
-- name: install node
-  ansible.builtin.shell: "{{ mise_bin }} use --global node@{{ node_version }}"
-  when: check_installed_node.rc != 0
+- name: configure mise global tools
+  ansible.builtin.template:
+    src: config.toml.j2
+    dest: "{{ ansible_env.HOME }}/.config/mise/config.toml"
+    mode: "0644"
+  register: mise_config
 
-- name: check installed ruby version
-  ansible.builtin.shell: "{{ mise_bin }} list ruby | grep {{ ruby_version }}"
-  register: check_installed_ruby
-  failed_when: false
-  changed_when: false
-
-- name: install ruby
-  ansible.builtin.shell: "{{ mise_bin }} use --global ruby@{{ ruby_version }}"
-  when: check_installed_ruby.rc != 0
-
-- name: check installed go version
-  ansible.builtin.shell: "{{ mise_bin }} list go | grep {{ go_version }}"
-  register: check_installed_go
-  failed_when: false
-  changed_when: false
-
-- name: install go
-  ansible.builtin.shell: "{{ mise_bin }} use --global go@{{ go_version }}"
-  when: check_installed_go.rc != 0
-
-- name: check installed rust version
-  ansible.builtin.shell: "{{ mise_bin }} list rust | grep {{ rust_version }}"
-  register: check_installed_rust
-  failed_when: false
-  changed_when: false
-
-- name: install rust
-  ansible.builtin.shell: "{{ mise_bin }} use --global rust@{{ rust_version }}"
-  when: check_installed_rust.rc != 0
-
-- name: check installed codex version
-  ansible.builtin.shell: "{{ mise_bin }} list codex | grep {{ codex_version }}"
-  register: check_installed_codex
-  failed_when: false
-  changed_when: false
-
-- name: install codex
-  ansible.builtin.shell: "{{ mise_bin }} use --global codex@{{ codex_version }}"
-  when: check_installed_codex.rc != 0
+- name: install mise global tools
+  ansible.builtin.shell: "{{ mise_bin }} install"
+  when: mise_config.changed
+  changed_when: true
 
 - name: check installed npm packages
   ansible.builtin.shell: "{{ mise_bin }} exec -- npm list -g --depth=0 {{ item.split('@')[0] }}"

--- a/.ansible/roles/mise/templates/config.toml.j2
+++ b/.ansible/roles/mise/templates/config.toml.j2
@@ -1,0 +1,7 @@
+# This file is managed by Ansible. Do not edit manually.
+[tools]
+codex = "{{ codex_version }}"
+go = "{{ go_version }}"
+node = "{{ node_version }}"
+ruby = "{{ ruby_version }}"
+rust = "{{ rust_version }}"


### PR DESCRIPTION
## 概要
mise ロールで node/ruby/go/rust/codex の global バージョン指定が常にスキップされるバグを修正する。

`mise list` はインストール済みバイナリの有無しか確認しないため、`~/.config/mise/config.toml` に書き込む `mise use --global` が実行されなかった。config.toml をテンプレートで直接配置する方式に変更することでバグを解消する。

## 変更内容
- `roles/mise/templates/config.toml.j2` を新規追加（node/ruby/go/rust/codex のバージョンを列挙）
- `roles/mise/tasks/main.yml`: 各ツールの check/install タスク（10タスク）を template 配置 + `mise install` の3タスクに統合

## QA手順
- `ansible-playbook -i .ansible/inventory .ansible/site.yml --tags mise -K` を実行
- `~/.config/mise/config.toml` に codex エントリが追記されることを確認
- `codex --version` が実行できることを確認

## 影響範囲
- mise ロールのみ。他ロール（neovim, claudecode 等）のバージョン変数参照は inventory 経由のため影響なし