### PR TITLE
feat: statusline に現在のブランチの PR タイトルを表示

### DIFF
--- a/.ansible/roles/claudecode/files/statusline.sh
+++ b/.ansible/roles/claudecode/files/statusline.sh
@@ -14,7 +14,7 @@ WEEK_RESET=$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // empty')
 PCT=${PCT:-0}; COST=${COST:-0}; DURATION_MS=${DURATION_MS:-0}
 [ "$PCT" -gt 100 ] && PCT=100
 
-GREEN='\033[32m'; YELLOW='\033[33m'; RED='\033[31m'; CYAN='\033[36m'; RESET='\033[0m'
+GREEN='\033[32m'; YELLOW='\033[33m'; RED='\033[31m'; CYAN='\033[36m'; MAGENTA='\033[35m'; RESET='\033[0m'
 
 if [ "$PCT" -ge 90 ]; then BAR_COLOR="$RED"
 elif [ "$PCT" -ge 70 ]; then BAR_COLOR="$YELLOW"
@@ -58,4 +58,42 @@ if [ -n "$WEEK" ]; then
   [ -n "$WEEK_REM" ] && LIMITS="${LIMITS}(${WEEK_REM})"
 fi
 
-printf '%b\n' "${CYAN}[${MODEL}]${RESET} ${BAR_COLOR}${BAR}${RESET} ${PCT}% | ${YELLOW}${COST_FMT}${RESET} | ${MINS}m ${SECS}s${LIMITS}"
+PR_INFO=""
+CWD=$(echo "$input" | jq -r '.workspace.current_dir // empty')
+if [ -n "$CWD" ] && command -v gh >/dev/null 2>&1 && command -v git >/dev/null 2>&1; then
+  REPO_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null)
+  BRANCH=$(git -C "$CWD" rev-parse --abbrev-ref HEAD 2>/dev/null)
+  case "$BRANCH" in
+    ""|HEAD|main|master|develop) ;;
+    *)
+      if [ -n "$REPO_ROOT" ]; then
+        CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/claude-pr-cache"
+        mkdir -p "$CACHE_DIR" 2>/dev/null
+        CACHE_KEY=$(printf '%s' "${REPO_ROOT}:${BRANCH}" | shasum 2>/dev/null | cut -c1-16)
+        if [ -n "$CACHE_KEY" ]; then
+          CACHE_FILE="${CACHE_DIR}/${CACHE_KEY}"
+          CACHE_MTIME=0
+          if [ -f "$CACHE_FILE" ]; then
+            PR_INFO=$(cat "$CACHE_FILE")
+            CACHE_MTIME=$(stat -f %m "$CACHE_FILE" 2>/dev/null || stat -c %Y "$CACHE_FILE" 2>/dev/null || echo 0)
+          fi
+          CACHE_AGE=$(( $(date +%s) - CACHE_MTIME ))
+          if [ "$CACHE_AGE" -gt 300 ] && mkdir "${CACHE_FILE}.lock" 2>/dev/null; then
+            (
+              trap 'rmdir "${CACHE_FILE}.lock" 2>/dev/null' EXIT
+              cd "$REPO_ROOT" || exit
+              pr_data=$(gh pr view "$BRANCH" --json number,title --jq '"#\(.number) \(.title)"' 2>/dev/null | tr -d '\n')
+              tmp_file=$(mktemp "${CACHE_DIR}/.pr-XXXXXX" 2>/dev/null) || exit
+              printf '%s' "$pr_data" > "$tmp_file" && mv "$tmp_file" "$CACHE_FILE"
+              find "$CACHE_DIR" -type f -mtime +7 -delete 2>/dev/null
+            ) >/dev/null 2>&1 &
+          fi
+        fi
+      fi
+      ;;
+  esac
+fi
+PR_SUFFIX=""
+[ -n "$PR_INFO" ] && PR_SUFFIX=" | ${MAGENTA}${PR_INFO}${RESET}"
+
+printf '%b\n' "${CYAN}[${MODEL}]${RESET} ${BAR_COLOR}${BAR}${RESET} ${PCT}% | ${YELLOW}${COST_FMT}${RESET} | ${MINS}m ${SECS}s${LIMITS}${PR_SUFFIX}"


### PR DESCRIPTION
## 概要
並列 PR 作業中に「どの PR を触っているか」を一目で確認できるよう、statusline 末尾に現在のブランチの GitHub PR 番号とタイトルをマゼンタ色で追加表示する。Claude Code 組み込みの「accept edits on」横 PR 番号表示はカスタマイズ不可のため、`~/.claude/statusline.sh` の出力末尾に追加する。

## 変更内容
- `.ansible/roles/claudecode/files/statusline.sh` に PR 情報取得ロジックを追加
  - JSON 入力の `workspace.current_dir` から repo / branch を解決
  - `main` / `develop` / `master` / HEAD / 空ブランチでは非表示
  - `gh pr view <branch>` の結果を `~/.cache/claude-pr-cache/<sha16>` に 5 分キャッシュ
  - キャッシュ期限切れ時のみバックグラウンドで更新（描画ブロックなし）
  - `mkdir` によるロックで多重 `gh` 起動を防止
  - `find -mtime +7 -delete` で 7 日超えキャッシュを GC
  - アトミック書き込み（mktemp + mv）で race condition を防止

## QA 手順
1. Ansible で `claudecode` ロールを再実行して `~/.claude/statusline.sh` を反映
2. feature ブランチの Claude Code セッションを開き、statusline 末尾に `#<番号> <PR タイトル>` がマゼンタで出ることを確認（初回は空、次回レンダリングで表示）
3. `main` / `develop` ブランチでは表示されないことを確認
4. PR 未作成ブランチでは何も出ないことを確認
5. 複数セッション起動でもプロセスが大量に湧かないことを確認

## 影響範囲
- `~/.claude/statusline.sh`（Ansible 実行者全員）
- 新規外部コマンド: `gh`（未インストール時は機能がスキップされるだけ）