### PR TITLE
feat: Stop hook で git fetch を自動実行（1時間スロットル付き）

### DIFF
--- a/.ansible/roles/claudecode/defaults/main.yml
+++ b/.ansible/roles/claudecode/defaults/main.yml
@@ -9,6 +9,7 @@ claudecode_dir:
   - "~/.claude/commands"
   - "~/.claude/agents"
   - "~/.claude/rules"
+  - "~/.claude/hooks"
   - "~/.claude/skills/backend-dev"
   - "~/.claude/skills/infra-quick-check"
   - "~/.claude/skills/sql-helper"
@@ -16,6 +17,9 @@ claudecode_dir:
   - "~/.claude/skills/investigate"
   - "~/.claude/skills/data-analysis"
   - "~/.claude/skills/gcp-verify"
+
+# git fetch throttle: directories to scan for git repos (space-separated)
+claudecode_git_fetch_dirs: "{{ ansible_env.HOME }}/src"
 
 # Claude Code plugins (non-LSP)
 # https://github.com/anthropics/claude-plugins-official

--- a/.ansible/roles/claudecode/files/hooks/git-fetch-throttle.sh
+++ b/.ansible/roles/claudecode/files/hooks/git-fetch-throttle.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+STATE_FILE="$HOME/.claude/.git-fetch-last-run"
+INTERVAL=3600 # 1 hour
+SEARCH_DIR="${GIT_FETCH_DIRS:-$HOME/src}"
+
+if [ -f "$STATE_FILE" ]; then
+    last=$(cat "$STATE_FILE")
+    now=$(date +%s)
+    if [[ "$last" =~ ^[0-9]+$ ]] && [ $((now - last)) -lt $INTERVAL ]; then
+        exit 0
+    fi
+fi
+
+date +%s > "$STATE_FILE"
+
+find "$SEARCH_DIR" -maxdepth 2 -name ".git" -type d 2>/dev/null | while IFS= read -r gitdir; do
+    repo="${gitdir%/.git}"
+    git -C "$repo" fetch --all --prune --quiet 2>/dev/null &
+done
+wait || true # ignore fetch failures (network unavailable etc.)

--- a/.ansible/roles/claudecode/tasks/main.yml
+++ b/.ansible/roles/claudecode/tasks/main.yml
@@ -80,6 +80,15 @@
     dest: "{{ ansible_env.HOME }}/.claude/statusline.sh"
     mode: 0755
 
+# ============================================
+# Claude Code Hooks
+# ============================================
+- name: copy git-fetch-throttle hook script
+  ansible.builtin.copy:
+    src: "hooks/git-fetch-throttle.sh"
+    dest: "{{ ansible_env.HOME }}/.claude/hooks/git-fetch-throttle.sh"
+    mode: 0755
+
 - name: deploy settings.json to ~/.claude
   ansible.builtin.template:
     src: "settings.json.j2"

--- a/.ansible/roles/claudecode/templates/settings.json.j2
+++ b/.ansible/roles/claudecode/templates/settings.json.j2
@@ -57,6 +57,10 @@
 {% else %}
             "command": "notify-send 'Claude Code' '入力待ちです'"
 {% endif %}
+          },
+          {
+            "type": "command",
+            "command": "GIT_FETCH_DIRS='{{ claudecode_git_fetch_dirs }}' {{ ansible_env.HOME }}/.claude/hooks/git-fetch-throttle.sh"
           }
         ]
       }


### PR DESCRIPTION
## 概要
Claude Code の Stop hook で `~/src` 配下の git リポジトリを自動 fetch する仕組みを追加。develop ブランチが古くなりがちな問題を、セッション終了時のバックグラウンド fetch で軽減する。

## 変更内容
- `claudecode` ロールに fetch スクリプト (`files/hooks/git-fetch-throttle.sh`) を追加
  - 1時間スロットル（`~/.claude/.git-fetch-last-run` で前回実行時刻管理）
  - `~/src` 配下を深さ2までスキャンし `git fetch --all --prune` を実行
  - 非同期 & サイレント（Claude 出力に影響しない）
- `settings.json.j2` の Stop hook にスクリプト呼び出しを追加
- `tasks/main.yml` に hooks ディレクトリ作成 + スクリプト配置タスクを追加
- `defaults/main.yml` に `~/.claude/hooks` ディレクトリと `claudecode_git_fetch_dirs` 変数を追加（デフォルト: `~/src`、上書き可能）

## QA手順
1. `ansible-playbook .ansible/site.yml -i .ansible/inventory --tags claudecode` でロール適用
2. `~/.claude/hooks/git-fetch-throttle.sh` が実行権限付きで配置されていることを確認
3. Claude Code を起動→終了し、fetch が実行されること（初回はスロットルなし）を確認
4. すぐ再起動→終了し、スロットルでスキップされることを確認
5. `touch -t 202001010000 ~/.claude/.git-fetch-last-run` でタイムスタンプを過去に書き換え→再 fetch が走ることを確認

## 影響範囲
- Claude Code の Stop hook（既存の通知に加えて fetch が追加）
- `~/.claude/hooks/` ディレクトリ（新規）
- `~/src` 配下の全 git リポジトリ（fetch のみ、マージなし・安全）