### PR TITLE
chore: add wrangler, bump claude_code_version, allow Chrome MCP

### DIFF
--- a/.ansible/roles/claudecode/defaults/main.yml
+++ b/.ansible/roles/claudecode/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Claude Code 設定
 
-claude_code_version: "2.1.119"
+claude_code_version: "2.1.123"
 
 # Claude Code directories
 claudecode_dir:

--- a/.ansible/roles/claudecode/templates/settings.json.j2
+++ b/.ansible/roles/claudecode/templates/settings.json.j2
@@ -10,7 +10,12 @@
       "Grep(**)",
       "Bash",
       "WebSearch",
-      "WebFetch"
+      "WebFetch",
+      "mcp__Claude_in_Chrome__navigate",
+      "mcp__Claude_in_Chrome__computer",
+      "mcp__Claude_in_Chrome__tabs_context_mcp",
+      "mcp__Claude_in_Chrome__read_page",
+      "mcp__Claude_in_Chrome__tabs_create_mcp"
     ],
     "deny": [
       "Read(tmp/**)",

--- a/.ansible/roles/mise/defaults/main.yml
+++ b/.ansible/roles/mise/defaults/main.yml
@@ -8,6 +8,7 @@ npm_packages:
   - "typescript@5.7.3"
   - "@modelcontextprotocol/server-sequential-thinking@2025.7.1"
   - "@upstash/context7-mcp@1.0.26"
+  - "wrangler@4.86.0"
 
 go_packages:
   - "github.com/lighttiger2505/sqls@v0.2.20"


### PR DESCRIPTION
## 概要
- mise 経由で wrangler (Cloudflare Workers CLI) をインストールできるようにする
- Claude Code を最新版にアップデート
- Claude in Chrome の MCP ツールを permissions.allow に追加

## 変更内容
- `.ansible/roles/mise/defaults/main.yml` の `npm_packages` に `wrangler@4.86.0` を追加
- `.ansible/roles/claudecode/defaults/main.yml` の `claude_code_version` を `2.1.119` → `2.1.123` に更新
- `.ansible/roles/claudecode/templates/settings.json.j2` の `permissions.allow` に以下を追加
  - `mcp__Claude_in_Chrome__navigate`
  - `mcp__Claude_in_Chrome__computer`
  - `mcp__Claude_in_Chrome__tabs_context_mcp`
  - `mcp__Claude_in_Chrome__read_page`
  - `mcp__Claude_in_Chrome__tabs_create_mcp`

## QA手順
1. `ansible-playbook .ansible/site.yml -i .ansible/inventory --tags mise,claudecode` を実行
2. `mise exec -- wrangler --version` で `4.86.0` が表示されることを確認
3. `claude --version` で `2.1.123` が表示されることを確認
4. `~/.claude/settings.json` に Claude in Chrome の MCP ツールが許可されていることを確認

## 影響範囲
- mise ロール経由で npm パッケージを追加インストール
- claudecode ロールで管理される Claude Code バージョンと settings.json を更新