### PR TITLE
chore: remove cost display from statusline

### DIFF
--- a/.ansible/roles/claudecode/files/statusline.sh
+++ b/.ansible/roles/claudecode/files/statusline.sh
@@ -4,14 +4,13 @@ input=$(cat)
 
 MODEL=$(echo "$input" | jq -r '.model.display_name')
 PCT=$(echo "$input" | jq -r '.context_window.used_percentage // 0' | cut -d. -f1)
-COST=$(echo "$input" | jq -r '.cost.total_cost_usd // 0')
 DURATION_MS=$(echo "$input" | jq -r '.cost.total_duration_ms // 0')
 FIVE_H=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
 FIVE_H_RESET=$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // empty')
 WEEK=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
 WEEK_RESET=$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // empty')
 
-PCT=${PCT:-0}; COST=${COST:-0}; DURATION_MS=${DURATION_MS:-0}
+PCT=${PCT:-0}; DURATION_MS=${DURATION_MS:-0}
 [ "$PCT" -gt 100 ] && PCT=100
 
 GREEN='\033[32m'; YELLOW='\033[33m'; RED='\033[31m'; CYAN='\033[36m'; MAGENTA='\033[35m'; RESET='\033[0m'
@@ -27,7 +26,6 @@ BAR=""
 [ "$FILLED" -gt 0 ] && printf -v FILL "%${FILLED}s" && BAR="${FILL// /█}"
 [ "$EMPTY" -gt 0 ] && printf -v PAD "%${EMPTY}s" && BAR="${BAR}${PAD// /░}"
 
-COST_FMT=$(printf '$%.2f' "$COST")
 MINS=$((DURATION_MS / 60000))
 SECS=$(((DURATION_MS % 60000) / 1000))
 
@@ -96,4 +94,4 @@ fi
 PR_SUFFIX=""
 [ -n "$PR_INFO" ] && PR_SUFFIX=" | ${MAGENTA}${PR_INFO}${RESET}"
 
-printf '%b\n' "${CYAN}[${MODEL}]${RESET} ${BAR_COLOR}${BAR}${RESET} ${PCT}% | ${YELLOW}${COST_FMT}${RESET} | ${MINS}m ${SECS}s${LIMITS}${PR_SUFFIX}"
+printf '%b\n' "${CYAN}[${MODEL}]${RESET} ${BAR_COLOR}${BAR}${RESET} ${PCT}% | ${MINS}m ${SECS}s${LIMITS}${PR_SUFFIX}"


### PR DESCRIPTION
## 概要
ステータスラインのコスト表示 (`$0.00`) は実用的価値が薄いため削除する。

## 変更内容
- `.ansible/roles/claudecode/files/statusline.sh` から `COST` / `COST_FMT` の取得・初期化・出力部分を削除

## QA手順
1. `ansible-playbook .ansible/site.yml -i .ansible/inventory --tags claudecode` を実行
2. Claude Code を再起動し、ステータスラインに `$0.00` 等のコスト表示が出ないことを確認
3. モデル名・コンテキスト使用率・経過時間・レート制限・PR 情報は引き続き表示されることを確認

## 影響範囲
ステータスライン表示のみ。他機能への影響なし。