### PR TITLE
feat: Neovim コードリーディング支援プラグインを追加

### DIFF
--- a/.ansible/roles/neovim/defaults/main.yml
+++ b/.ansible/roles/neovim/defaults/main.yml
@@ -9,6 +9,7 @@ neovim_dir:
   - "~/.config/sqls"
   - "~/.config/lazygit"
   - "/usr/local/src/nvim"
+  - "~/.local/share/nvim/sessions"
 neovim_plugins:
   - name: "airblade/vim-gitgutter"
     version: "00df1089b6267f47c7c0f13536789feb9db1e65b"
@@ -89,6 +90,15 @@ neovim_plugins:
     version: "9a88eae817ef395952e08650b3283726786fb5fb"
   - name: "sindrets/diffview.nvim"
     version: "4516612fe98ff56ae0415a259ff6361a89419b0a"
+  # コードリーディング支援
+  - name: "nvim-treesitter/nvim-treesitter"
+    version: "4916d6592ede8c07973490d9322f187e07dfefac"
+  - name: "nvim-treesitter/nvim-treesitter-context"
+    version: "b0c45cefe2c8f7b55fc46f34e563bc428ef99636"
+  - name: "stevearc/aerial.nvim"
+    version: "645d108a5242ec7b378cbe643eb6d04d4223f034"
+  - name: "folke/persistence.nvim"
+    version: "b20b2a7887bd39c1a356980b45e03250f3dce49c"
 db_user: "postgres"
 db_password: ""
 db_dbname: "postgres"

--- a/.ansible/roles/neovim/templates/init.vim.j2
+++ b/.ansible/roles/neovim/templates/init.vim.j2
@@ -773,6 +773,80 @@ augroup vimrcEx
 augroup END
 
 " ============================================
+" nvim-treesitter - 構文解析・ハイライト
+" ============================================
+" 使い方:
+"   <Ctrl-Space>    : 選択範囲をノード単位で拡張（ノーマルモード。インサートモードでは補完トリガー）
+"   <BS>            : 選択範囲を縮小
+lua <<EOF
+local treesitter_ok, treesitter = pcall(require, "nvim-treesitter.configs")
+if treesitter_ok then
+  treesitter.setup({
+    ensure_installed = { "ruby", "go", "rust", "typescript", "javascript", "python", "lua", "bash" },
+    auto_install     = false,
+    highlight = { enable = true },
+    indent    = { enable = true },
+    incremental_selection = {
+      enable = true,
+      keymaps = {
+        init_selection    = "<C-space>",
+        node_incremental  = "<C-space>",
+        scope_incremental = false,
+        node_decremental  = "<bs>",
+      },
+    },
+  })
+end
+EOF
+
+" ============================================
+" nvim-treesitter-context - スコープのスティッキー表示
+" ============================================
+lua <<EOF
+local ts_context_ok, ts_context = pcall(require, "treesitter-context")
+if ts_context_ok then
+  ts_context.setup({
+    enable    = true,
+    max_lines = 3,
+  })
+end
+EOF
+
+" ============================================
+" aerial.nvim - シンボルアウトライン
+" ============================================
+" 使い方:
+"   <leader>a       : アウトラインをトグル
+lua <<EOF
+local aerial_ok, aerial = pcall(require, "aerial")
+if aerial_ok then
+  aerial.setup({
+    backends    = { "treesitter", "lsp" },
+    layout      = { max_width = { 40, 0.2 }, min_width = 30 },
+    show_guides = true,
+  })
+  vim.keymap.set('n', '<leader>a', '<cmd>AerialToggle!<CR>', { silent = true, desc = "Toggle aerial outline" })
+end
+EOF
+
+" ============================================
+" persistence.nvim - セッション自動保存・復元
+" ============================================
+" 使い方:
+"   <leader>qs      : 現在の cwd のセッションを復元
+"   <leader>ql      : 最後のセッションを復元
+"   <leader>qd      : セッション保存を無効化（一時的な使い捨て起動）
+lua <<EOF
+local persistence_ok, persistence = pcall(require, "persistence")
+if persistence_ok then
+  persistence.setup()
+  vim.keymap.set('n', '<leader>qs', function() persistence.load() end,              { silent = true, desc = "Restore session" })
+  vim.keymap.set('n', '<leader>ql', function() persistence.load({ last = true }) end, { silent = true, desc = "Restore last session" })
+  vim.keymap.set('n', '<leader>qd', function() persistence.stop() end,              { silent = true, desc = "Don't save session" })
+end
+EOF
+
+" ============================================
 " WSL用設定 - クリップボード連携
 " ============================================
 if system('uname -a | grep microsoft') != ''


### PR DESCRIPTION
## 概要
コードリーディング体験向上のため、Neovim に最低限の 4 プラグインを追加する。
RubyMine 等の IDE 比で不足していた「構造把握」「コンテキスト保持」「セッション復元」を補うのが目的。

## 変更内容
- `defaults/main.yml` の `neovim_plugins` に以下を追加
  - `nvim-treesitter/nvim-treesitter`（構文解析・ハイライトの基盤）
  - `nvim-treesitter/nvim-treesitter-context`（スコープのスティッキー表示）
  - `stevearc/aerial.nvim`（シンボルアウトライン）
  - `folke/persistence.nvim`（cwd 単位のセッション自動保存・復元）
- `defaults/main.yml` の `neovim_dir` に `~/.local/share/nvim/sessions` を追加（persistence のセッション保存先）
- `init.vim.j2` に各プラグインの setup ブロックとキーマップを追加
  - `<leader>a` : aerial toggle
  - `<leader>qs` / `<leader>ql` / `<leader>qd` : persistence セッション操作
  - treesitter / treesitter-context はセットアップのみ（Ruby/Go/Rust/TS 等 8 言語を `ensure_installed` に指定）

## QA手順
1. `ansible-playbook .ansible/site.yml -i .ansible/inventory --tags neovim` でロール適用
2. `nvim` 起動後 `:TSInstall! ruby rust go typescript javascript python lua bash` でパーサー取得（`ensure_installed` で初回起動時に自動ダウンロードも可）
3. Ruby/Rust ファイルでハイライトが treesitter ベースになっていること
4. ネストの深い関数で上部にコンテキストが固定表示されること
5. `<leader>a` でアウトラインが開くこと
6. プロジェクトルートで `nvim` を起動し、ファイルを数枚開いて終了 → 同ディレクトリで `nvim` 再起動 → `<leader>qs` で前回開いていたバッファが復元されること

## 影響範囲
- `~/.config/nvim/init.vim` および Neovim プラグイン構成のみ
- 他ロール・既存プラグインへの影響なし