### PR TITLE
fix(neovim): neo-tree のサイドバー背景をメインと同じ透過に揃える

### DIFF
--- a/.ansible/roles/neovim/templates/init.vim.j2
+++ b/.ansible/roles/neovim/templates/init.vim.j2
@@ -30,6 +30,9 @@ highlight NormalNC guibg=NONE ctermbg=NONE
 highlight EndOfBuffer guibg=NONE ctermbg=NONE
 highlight SignColumn guibg=NONE ctermbg=NONE
 highlight WinSeparator guifg=#3b4261 guibg=NONE
+highlight NeoTreeNormal guibg=NONE ctermbg=NONE
+highlight NeoTreeNormalNC guibg=NONE ctermbg=NONE
+highlight NeoTreeEndOfBuffer guibg=NONE ctermbg=NONE
 
 " ============================================
 " GraphQL / Denops設定


### PR DESCRIPTION
## 概要
neo-tree のサイドバー背景色がメインエディタと違って浮いて見える問題を修正する。
メインエディタは `Normal guibg=NONE` で透過しているのに対し、neo-tree は tokyonight の不透明な既定色が当たるため違和感が出ていた。

## 変更内容
- `roles/neovim/templates/init.vim.j2` の透過 highlight ブロックに、`NeoTreeNormal` / `NeoTreeNormalNC` / `NeoTreeEndOfBuffer` を `guibg=NONE` で上書きする 3 行を追加し、メインの透過と揃えた。

## QA手順
- `ansible-playbook .ansible/site.yml -i .ansible/inventory --tags neovim` を実行
- nvim 起動 → `<C-n>` で neo-tree を開き、サイドバー背景がメインエディタと同じく透過（ターミナル背景が透ける）になっていることを確認

## 影響範囲
- nvim の neo-tree 表示時の見た目のみ。他プラグイン・キーバインド・Ansible 実行ロジックへの影響なし。
