### PR TITLE
feat(claudecode): voice モードで離鍵時の自動投稿を有効化

### DIFF
--- a/.ansible/roles/claudecode/defaults/main.yml
+++ b/.ansible/roles/claudecode/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Claude Code 設定
 
-claude_code_version: "2.1.123"
+claude_code_version: "2.1.126"
 
 # Claude Code directories
 claudecode_dir:

--- a/.ansible/roles/claudecode/templates/settings.json.j2
+++ b/.ansible/roles/claudecode/templates/settings.json.j2
@@ -75,7 +75,11 @@
     "type": "command",
     "command": "{{ ansible_env.HOME }}/.claude/statusline.sh"
   },
-  "voiceEnabled": true,
+  "voice": {
+    "enabled": true,
+    "mode": "hold",
+    "autoSubmit": true
+  },
   "language": "Japanese",
   "env": {
     "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",


### PR DESCRIPTION
## 概要
1. Claude Code の voice モード（hold-to-talk）でスペースキーを離した瞬間に、文字起こしが3語以上なら自動投稿されるよう設定する。あわせて旧フラットキー `voiceEnabled` を現行スキーマのネスト形式 `voice` に正規化する。
2. Claude Code を `2.1.123` → `2.1.126` にアップグレード。

## 変更内容
- `.ansible/roles/claudecode/templates/settings.json.j2`
  - `"voiceEnabled": true`（フラット形式）を削除
  - `voice` ブロック（`enabled` / `mode: "hold"` / `autoSubmit: true`）を追加
- `.ansible/roles/claudecode/defaults/main.yml`
  - `claude_code_version: "2.1.123"` → `"2.1.126"`

## QA手順
1. `cd .ansible && ansible-playbook site.yml -i inventory --tags claudecode`
2. `claude --version` が `2.1.126 (Claude Code)` を返すことを確認
3. `jq '.voice, .voiceEnabled' ~/.claude/settings.json` で以下を確認
   - `.voice` が `{ "enabled": true, "mode": "hold", "autoSubmit": true }`
   - `.voiceEnabled` が `null`（消えている）
4. Claude Code を再起動 → voice モード（hold）でスペース押下中に話し、離した瞬間に3語以上なら自動投稿されることを確認

## 影響範囲
- `~/.claude/settings.json` の voice 関連設定
- Claude Code バイナリ本体（`~/.local/bin/claude`）
- Claude Code 以外への影響なし
