### PR TITLE
feat: simplify neovim search keymaps to ctrl-chord style

### DIFF
--- a/.ansible/roles/neovim/templates/init.vim.j2
+++ b/.ansible/roles/neovim/templates/init.vim.j2
@@ -312,12 +312,14 @@ autocmd TermOpen * startinsert
 " ============================================
 " fzf-lua - ファジーファインダー
 " ============================================
-" 使い方:
-"   <Ctrl-p>        : プロジェクト内のファイルを検索
+" 使い方（ノーマルモード）:
+"   <Ctrl-p>        : プロジェクト内のファイルを検索（ファイル名）
+"   <Ctrl-f>        : プロジェクト内をgrep検索（live grep / ファイル内容）
+"                     ※ インサートモードの <Ctrl-f> は nvim-cmp 補完ドキュメントのスクロール
+"   <Ctrl-g>        : カーソル下の単語でgrep検索
 "   gs              : Git statusのファイルを検索
 "   gl              : Gitログを表示
-"   gr <keyword>    : プロジェクト内をgrep検索（live grep）
-"   ビジュアルモードで gr : 選択したテキストをgrep検索
+"   ビジュアルモードで <Ctrl-f> : 選択したテキストをgrep検索
 "   検索結果内で:
 "     <Enter>       : ファイルを開く
 "     <Ctrl-t>      : 新しいタブで開く
@@ -348,10 +350,11 @@ if fzf_lua_ok then
   })
 
   vim.keymap.set('n', '<C-p>', fzf_lua.files, { silent = true, desc = "Find files" })
+  vim.keymap.set('n', '<C-f>', fzf_lua.live_grep, { silent = true, desc = "Live grep" })
+  vim.keymap.set('n', '<C-g>', fzf_lua.grep_cword, { silent = true, desc = "Grep word under cursor" })
+  vim.keymap.set('x', '<C-f>', fzf_lua.grep_visual, { silent = true, desc = "Grep visual selection" })
   vim.keymap.set('n', 'gs', fzf_lua.git_status, { silent = true, desc = "Git status" })
   vim.keymap.set('n', 'gl', fzf_lua.git_commits, { silent = true, desc = "Git log" })
-  vim.keymap.set('n', 'gr', fzf_lua.live_grep, { silent = true, desc = "Live grep" })
-  vim.keymap.set('x', 'gr', fzf_lua.grep_visual, { silent = true, desc = "Grep visual selection" })
 end
 EOF
 
@@ -488,9 +491,10 @@ lua <<EOF
   -- ============================================
   -- nvim-cmp 補完設定
   -- ============================================
-  -- 使い方:
+  -- 使い方（インサートモードの補完メニュー内）:
   --   <Ctrl-b>      : 補完ドキュメントを上にスクロール
   --   <Ctrl-f>      : 補完ドキュメントを下にスクロール
+  --                   ※ ノーマルモードの <Ctrl-f> は fzf-lua の live grep
   --   <Ctrl-Space>  : 補完を手動でトリガー
   --   <Ctrl-e>      : 補完をキャンセル
   --   <Enter>       : 選択した補完を確定


### PR DESCRIPTION
## 概要
Neovim でのファイル名検索・ファイル内容検索を VS Code 風の Ctrl 単打キーバインドに統一し、`gr` の LSP デフォルトキーマップ（`grr` / `gra` 等）と衝突する問題を解消する。

## 変更内容
- `<C-p>`: ファイル名検索（変更なし）
- `<C-f>`: プロジェクト内 live grep（`gr` から移行）
- `<C-g>`: カーソル下の単語を即 grep（`grep_cword`、新設）
- ビジュアルモード `<C-f>`: 選択範囲を grep（旧: ビジュアル `gr`）
- `gr` キーマップは削除（LSP の `grr`/`gra`/`gri`/`grn`/`grt` と衝突するタイムアウト問題を解消）
- コメントでモード（normal / insert / visual）を明示

## QA手順
1. `ansible-playbook .ansible/site.yml -i .ansible/inventory --tags neovim` で適用
2. nvim を起動
3. `<C-p>` でファイル名検索ピッカーが開くことを確認
4. `<C-f>` で live grep ピッカーが開くことを確認
5. 任意の単語にカーソルを置き `<C-g>` でその単語の grep 結果が出ることを確認
6. ビジュアルモードで範囲選択して `<C-f>` で grep が動くことを確認
7. インサートモードで補完を出した状態で `<C-f>` がドキュメントスクロール（nvim-cmp）として機能することを確認
8. `gr` を押しても fzf-lua の grep が起動しない（LSP の `grr` 等のみ反応する）ことを確認

## 影響範囲
- Neovim のキーマップのみ
- ノーマルモードの Vim デフォルト `<C-f>`（1ページ前方スクロール）が上書きされる → `<C-d>` で代替可能
- `<C-g>`（ファイル情報表示）も上書き → `:f` で代替可能
- 既存ユーザーは `gr` の筋肉記憶の置き換えが必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)