### PR TITLE
fix(neovim): bump fzf to v0.72.0 to satisfy fzf-lua minimum version

### DIFF
--- a/.ansible/roles/neovim/defaults/main.yml
+++ b/.ansible/roles/neovim/defaults/main.yml
@@ -14,7 +14,7 @@ neovim_plugins:
   - name: "airblade/vim-gitgutter"
     version: "00df1089b6267f47c7c0f13536789feb9db1e65b"
   - name: "junegunn/fzf"
-    version: "46877e0a92d5e18bfc143ac98bb55b22eaef81ac"
+    version: "6fefe025461b168eac2546ccba3403b70eb5da16"
   - name: "ibhagwan/fzf-lua"
     version: "14e2ebc7ed4cef90ffb4fd192ca28c33741818eb"
   - name: "nvim-neo-tree/neo-tree.nvim"

--- a/.ansible/roles/neovim/tasks/main.yml
+++ b/.ansible/roles/neovim/tasks/main.yml
@@ -81,6 +81,29 @@
     path: "{{ neovim_plugin_path }}/claude-code.nvim"
     state: absent
 
+# fzf は update: false でバージョン変更が反映されないため、SHA ミスマッチ時にディレクトリごと削除して再クローンする
+- name: check current fzf commit
+  ansible.builtin.command: "git -C {{ neovim_plugin_path }}/fzf rev-parse HEAD"
+  register: fzf_current_commit
+  failed_when: false
+  changed_when: false
+
+- name: remove fzf directory if version mismatch
+  ansible.builtin.file:
+    path: "{{ neovim_plugin_path }}/fzf"
+    state: absent
+  when:
+    - fzf_current_commit.rc == 0
+    - fzf_current_commit.stdout | trim != (neovim_plugins | selectattr('name', 'equalto', 'junegunn/fzf') | list | first).version
+
+- name: remove fzf shell integration if version mismatch
+  ansible.builtin.file:
+    path: "{{ ansible_env.HOME }}/.fzf.bash"
+    state: absent
+  when:
+    - fzf_current_commit.rc == 0
+    - fzf_current_commit.stdout | trim != (neovim_plugins | selectattr('name', 'equalto', 'junegunn/fzf') | list | first).version
+
 - name: install neovim plugin
   ansible.builtin.git:
     repo: "https://github.com/{{ item.name }}.git"


### PR DESCRIPTION
## 概要
fzf-lua が "fzf version 0.35.0 is lower than minimum(0.36), aborting." で起動しなくなったため、ピン留めしていた fzf のバージョンを v0.72.0 に更新する。

## 変更内容
- `roles/neovim/defaults/main.yml`: `junegunn/fzf` の version を v0.72.0 のコミット (`6fefe025...`) に更新
- `roles/neovim/tasks/main.yml`: 既存 fzf のコミットが desired と異なる場合にディレクトリと `~/.fzf.bash` を削除するタスクを追加（`update: false` + `creates:` で更新されない問題への対応）

## QA手順
1. `ansible-playbook .ansible/site.yml -i .ansible/inventory --tags neovim` を実行
2. `~/.local/share/nvim/site/pack/plugins/start/fzf/bin/fzf --version` が `0.72.0` を返すことを確認
3. Neovim を起動し `Ctrl-p` / `Ctrl-f` / `Ctrl-g` がエラーなく動くことを確認
4. 再度 playbook を実行し冪等性（`changed=0`）を確認

## 影響範囲
- Neovim の fzf-lua ベースの検索機能（`Ctrl-p`, `Ctrl-f`, `Ctrl-g` 等）
- 他プラグインへの影響なし