### PR TITLE
feat(neovim): neo-tree フォーカス時でも fzf-lua 検索キーを使えるようにする

### DIFF
--- a/.ansible/roles/neovim/templates/init.vim.j2
+++ b/.ansible/roles/neovim/templates/init.vim.j2
@@ -389,6 +389,9 @@ EOF
 "     R             : リフレッシュ
 "     H             : 隠しファイルの表示/非表示
 "     /             : フィルター
+"     <Ctrl-p>      : ファイル名検索（エディタ側で開く）
+"     <Ctrl-f>      : ファイル内容検索（エディタ側で開く）
+"     <Ctrl-g>      : カーソル下の単語でgrep（エディタ側で開く）
 lua <<EOF
 local neotree_ok, neotree = pcall(require, "neo-tree")
 if neotree_ok then
@@ -427,6 +430,35 @@ if neotree_ok then
 end
 EOF
 nnoremap <C-n> :Neotree toggle<CR>
+
+" neo-tree フォーカス時でも fzf-lua 検索を使えるようにする
+" ツリー側でキーを押すと、エディタウィンドウへ移動してから検索を起動する
+lua <<EOF
+vim.api.nvim_create_autocmd("FileType", {
+  group = vim.api.nvim_create_augroup("NeoTreeFzfKeys", { clear = true }),
+  pattern = "neo-tree",
+  callback = function()
+    local fzf_lua_ok, fzf_lua = pcall(require, "fzf-lua")
+    if not fzf_lua_ok then return end
+    local opts = { buffer = true, silent = true }
+    local function jump_then(fn)
+      return function()
+        local cur = vim.api.nvim_get_current_win()
+        vim.cmd("wincmd p")
+        if vim.api.nvim_get_current_win() == cur then
+          vim.cmd("wincmd l")
+        end
+        -- エディタウィンドウへ移動できなかった場合は何もしない
+        if vim.bo[vim.api.nvim_get_current_win()].filetype == "neo-tree" then return end
+        fn()
+      end
+    end
+    vim.keymap.set('n', '<C-p>', jump_then(fzf_lua.files),      opts)
+    vim.keymap.set('n', '<C-f>', jump_then(fzf_lua.live_grep),  opts)
+    vim.keymap.set('n', '<C-g>', jump_then(fzf_lua.grep_cword), opts)
+  end,
+})
+EOF
 
 " ============================================
 " nvim-cmp, nvim-lspconfig - 補完とLSP設定


### PR DESCRIPTION
## 概要
neo-tree（ファイルツリー）にフォーカスがある状態でも、ファイル名検索（`<C-p>`）とファイル内容検索（`<C-f>`）・単語grep（`<C-g>`）を使えるようにする。

## 変更内容
- `init.vim.j2` に `FileType neo-tree` autocmd を追加
  - `<C-p>` / `<C-f>` / `<C-g>` を buffer-local なラッパーキーマップとして登録
  - キー押下時にエディタウィンドウへ移動（`wincmd p`、ダメなら `wincmd l`）してから fzf-lua を起動
  - エディタウィンドウへ移動できなかった場合（ツリーしか開いていない等）は何もしない
  - `augroup "NeoTreeFzfKeys" { clear = true }` で再ロード時の重複登録を防止
- neo-tree コメントブロックに新キーマップの説明を追記

## QA手順
1. neovim を開き `<C-n>` でファイルツリーを表示
2. カーソルをツリー側に置いたまま `<C-p>` → ファイル名検索が開き、選択したファイルがエディタ側で開くことを確認
3. 同様に `<C-f>` → live grep が正常動作することを確認
4. 同様に `<C-g>` → カーソル下の単語でgrep が起動することを確認
5. ツリーを閉じた状態（エディタのみ）でも `<C-p>` / `<C-f>` / `<C-g>` が引き続き動作することを確認

## 影響範囲
neovim の `init.vim` のみ。既存のグローバルキーマップは変更なし。