### PR TITLE
fix(neovim): neo-tree で <C-p> 押下時に Invalid buffer id エラーが出る問題を修正

### DIFF
--- a/.ansible/roles/neovim/templates/init.vim.j2
+++ b/.ansible/roles/neovim/templates/init.vim.j2
@@ -449,7 +449,7 @@ vim.api.nvim_create_autocmd("FileType", {
           vim.cmd("wincmd l")
         end
         -- エディタウィンドウへ移動できなかった場合は何もしない
-        if vim.bo[vim.api.nvim_get_current_win()].filetype == "neo-tree" then return end
+        if vim.bo.filetype == "neo-tree" then return end
         fn()
       end
     end


### PR DESCRIPTION
## 概要
neo-tree フォーカス中に `<C-p>` / `<C-f>` / `<C-g>` を押すと `E5108: Invalid buffer id: 1000` で落ちる不具合を修正。

## 変更内容
- `init.vim.j2` の `jump_then` クロージャ内で、ウィンドウIDをバッファIDとして誤用していた箇所を修正
  - `vim.bo[vim.api.nvim_get_current_win()].filetype` → `vim.bo.filetype`
  - `vim.bo[]` はバッファIDを期待するが `nvim_get_current_win()` はウィンドウID（例: 1000）を返す

## QA手順
1. Neovim を起動し `<C-n>` で neo-tree を開く
2. neo-tree にフォーカスを当てた状態で `<C-p>` を押す
3. エラーなく fzf-lua のファイル検索が起動することを確認

## 影響範囲
- neo-tree フォーカス時の `<C-p>` / `<C-f>` / `<C-g>` キーマップのみ