### PR TITLE
feat(ansible): add ollama role for local Gemma 4 setup

### DIFF
--- a/.ansible/roles/ollama/defaults/main.yml
+++ b/.ansible/roles/ollama/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+ollama_models:
+  - gemma4

--- a/.ansible/roles/ollama/tasks/main.yml
+++ b/.ansible/roles/ollama/tasks/main.yml
@@ -1,0 +1,62 @@
+---
+- name: setup ollama (macOS)
+  block:
+    - name: install ollama
+      community.general.homebrew:
+        name: ollama
+        state: present
+
+    - name: check ollama service status
+      ansible.builtin.command: brew services list
+      register: brew_services_list
+      changed_when: false
+      environment:
+        PATH: /opt/homebrew/bin:{{ ansible_env.PATH }}
+
+    - name: start ollama service
+      ansible.builtin.command: brew services start ollama
+      changed_when: true
+      environment:
+        PATH: /opt/homebrew/bin:{{ ansible_env.PATH }}
+      when: brew_services_list.stdout is not search('ollama.*started')
+  when: ansible_distribution == 'MacOSX'
+
+- name: setup ollama (Linux)
+  block:
+    - name: check if ollama is installed
+      ansible.builtin.stat:
+        path: /usr/local/bin/ollama
+      register: ollama_bin
+
+    - name: install ollama via official script
+      ansible.builtin.shell: "curl -fsSL https://ollama.com/install.sh | sh"
+      when: not ollama_bin.stat.exists
+      changed_when: true
+
+    - name: start and enable ollama service
+      ansible.builtin.systemd:
+        name: ollama
+        state: started
+        enabled: true
+      become: true
+      ignore_errors: true
+  when: ansible_distribution in ['Ubuntu', 'Debian']
+
+- name: wait for ollama service to be ready
+  ansible.builtin.command: ollama list
+  register: ollama_list
+  changed_when: false
+  retries: 5
+  delay: 2
+  until: ollama_list.rc == 0
+  ignore_errors: true
+
+- name: pull ollama models
+  ansible.builtin.command: "ollama pull {{ item }}"
+  loop: "{{ ollama_models }}"
+  vars:
+    installed_models: "{{ ollama_list.stdout_lines[1:] | map('split') | map('first') | list }}"
+  when:
+    - not ollama_list.failed
+    - item not in installed_models
+  changed_when: item not in installed_models

--- a/.ansible/site.yml
+++ b/.ansible/site.yml
@@ -14,6 +14,8 @@
       tags: codex
     - role: neovim
       tags: neovim
+    - role: ollama
+      tags: ollama
   post_tasks:
     - name: reboot wsl
       shell: "[ -e /mnt/c/Windows/system32/wsl.exe ] && /mnt/c/Windows/system32/wsl.exe -t Ubuntu-20.04"


### PR DESCRIPTION
## 概要
ローカルで Gemma 4 を動かすため、Ollama をセットアップする Ansible ロールを追加する。

## 変更内容
- `.ansible/roles/ollama/tasks/main.yml` を新規追加
  - macOS: `brew install ollama`（CLI formula、launchd サービス）
  - Linux/WSL: 公式スクリプト `curl -fsSL https://ollama.com/install.sh | sh`
  - サービス起動後に `ollama_models` 変数で指定したモデルを pull（デフォルト: `gemma4`）
  - WSL など systemd が使えない環境ではサービス起動をスキップ（`ignore_errors: true`）
- `.ansible/roles/ollama/defaults/main.yml` を新規追加（`ollama_models: [gemma4]`）
- `.ansible/site.yml` に `tags: ollama` でロールを追加

## QA 手順
```bash
# macOS
ansible-playbook .ansible/site.yml -i .ansible/inventory --tags ollama

# 特定モデルに変更したい場合
ansible-playbook .ansible/site.yml -i .ansible/inventory --tags ollama -e 'ollama_models=["gemma4:27b"]'

# 動作確認
ollama list
ollama run gemma4
```

## 影響範囲
- 新規ロールのため既存ロールへの影響なし
- site.yml への追加は末尾のみ（実行順序に変更なし）