### PR TITLE
feat(ansible): add aider role for local LLM coding agent

### DIFF
--- a/.ansible/roles/aider/defaults/main.yml
+++ b/.ansible/roles/aider/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+aider_model: "ollama_chat/gemma4"
+aider_num_ctx: 32768
+aider_auto_commits: true
+aider_dark_mode: true
+aider_yes_always: true
+aider_gitignore: true
+aider_analytics: false
+aider_check_update: false

--- a/.ansible/roles/aider/tasks/main.yml
+++ b/.ansible/roles/aider/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: check if aider is installed
+  ansible.builtin.stat:
+    path: "{{ ansible_env.HOME }}/.local/bin/aider"
+  register: aider_bin
+
+- name: install aider via official script
+  ansible.builtin.shell: "curl -fsSL https://aider.chat/install.sh | sh"
+  when: not aider_bin.stat.exists
+  changed_when: true
+
+- name: copy aider config (~/.aider.conf.yml)
+  ansible.builtin.template:
+    src: aider.conf.yml.j2
+    dest: "{{ ansible_env.HOME }}/.aider.conf.yml"
+    mode: "0644"

--- a/.ansible/roles/aider/templates/aider.conf.yml.j2
+++ b/.ansible/roles/aider/templates/aider.conf.yml.j2
@@ -1,0 +1,16 @@
+# Ansible managed - see roles/aider/defaults/main.yml for variables
+# Use ollama_chat/<model> to route through local Ollama (requires ollama role)
+model: {{ aider_model }}
+
+# yes-always/auto-commits are true for non-stop local LLM workflow
+auto-commits: {{ aider_auto_commits | string | lower }}
+yes-always: {{ aider_yes_always | string | lower }}
+
+dark-mode: {{ aider_dark_mode | string | lower }}
+gitignore: {{ aider_gitignore | string | lower }}
+analytics: {{ aider_analytics | string | lower }}
+check-update: {{ aider_check_update | string | lower }}
+
+# Increase Ollama context window from default 2048 (too small for code)
+extra-params:
+  num_ctx: {{ aider_num_ctx }}

--- a/.ansible/site.yml
+++ b/.ansible/site.yml
@@ -16,6 +16,8 @@
       tags: neovim
     - role: ollama
       tags: ollama
+    - role: aider
+      tags: aider
   post_tasks:
     - name: reboot wsl
       shell: "[ -e /mnt/c/Windows/system32/wsl.exe ] && /mnt/c/Windows/system32/wsl.exe -t Ubuntu-20.04"


### PR DESCRIPTION
## 概要
ローカル LLM 向けコーディングエージェント Aider をセットアップする Ansible ロールを追加する。ollama ロール（Gemma 4）と組み合わせることで、ローカル完結の AI コーディング環境が整う。

## 変更内容
- `.ansible/roles/aider/` を新規追加
  - 公式スクリプト `curl -fsSL https://aider.chat/install.sh | sh` でインストール（macOS/Linux 共通）
  - `~/.aider.conf.yml` をテンプレートで生成
- `.ansible/site.yml` に `tags: aider` でロールを追加

## 設定内容（~/.aider.conf.yml）
| 設定 | 値 | 理由 |
|------|-----|------|
| `model` | `ollama_chat/gemma4` | ollama ロールで pull 済みの Gemma 4 を使用 |
| `extra-params.num_ctx` | `32768` | Ollama デフォルト (2048) だとコード読み込みに不足 |
| `yes-always` | `true` | 確認プロンプトをスキップ（ノンストップ運用） |
| `auto-commits` | `true` | AI 変更を自動 git commit（差分追跡のため） |
| `analytics` | `false` | ローカル運用のため外部送信を抑制 |

## QA 手順
```bash
# インストール・設定
ansible-playbook .ansible/site.yml -i .ansible/inventory --tags aider

# 動作確認（任意のリポジトリで）
ollama serve  # 未起動の場合
cd ~/src/任意プロジェクト
aider

# モデルを変更したい場合
ansible-playbook .ansible/site.yml -i .ansible/inventory --tags aider -e 'aider_model=ollama_chat/gemma4:27b'
```

## 影響範囲
- 新規ロールのため既存ロールへの影響なし
- site.yml は末尾に追加のみ（実行順序変更なし）