### PR TITLE
fix(aider): fix extra-params config and set OLLAMA_API_BASE

### DIFF
--- a/.ansible/roles/aider/defaults/main.yml
+++ b/.ansible/roles/aider/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 aider_model: "ollama_chat/gemma4"
+aider_ollama_api_base: "http://127.0.0.1:11434"
 aider_num_ctx: 32768
 aider_auto_commits: true
 aider_dark_mode: true

--- a/.ansible/roles/aider/tasks/main.yml
+++ b/.ansible/roles/aider/tasks/main.yml
@@ -14,3 +14,9 @@
     src: aider.conf.yml.j2
     dest: "{{ ansible_env.HOME }}/.aider.conf.yml"
     mode: "0644"
+
+- name: copy aider model settings (~/.aider.model.settings.yml)
+  ansible.builtin.template:
+    src: aider.model.settings.yml.j2
+    dest: "{{ ansible_env.HOME }}/.aider.model.settings.yml"
+    mode: "0644"

--- a/.ansible/roles/aider/templates/aider.conf.yml.j2
+++ b/.ansible/roles/aider/templates/aider.conf.yml.j2
@@ -2,6 +2,13 @@
 # Use ollama_chat/<model> to route through local Ollama (requires ollama role)
 model: {{ aider_model }}
 
+# Set OLLAMA_API_BASE to silence "OLLAMA_API_BASE: Not set" warning
+set-env:
+  - OLLAMA_API_BASE={{ aider_ollama_api_base }}
+
+# Per-model settings (num_ctx etc.) - see ~/.aider.model.settings.yml
+model-settings-file: {{ ansible_env.HOME }}/.aider.model.settings.yml
+
 # yes-always/auto-commits are true for non-stop local LLM workflow
 auto-commits: {{ aider_auto_commits | string | lower }}
 yes-always: {{ aider_yes_always | string | lower }}
@@ -10,7 +17,3 @@ dark-mode: {{ aider_dark_mode | string | lower }}
 gitignore: {{ aider_gitignore | string | lower }}
 analytics: {{ aider_analytics | string | lower }}
 check-update: {{ aider_check_update | string | lower }}
-
-# Increase Ollama context window from default 2048 (too small for code)
-extra-params:
-  num_ctx: {{ aider_num_ctx }}

--- a/.ansible/roles/aider/templates/aider.model.settings.yml.j2
+++ b/.ansible/roles/aider/templates/aider.model.settings.yml.j2
@@ -1,0 +1,5 @@
+# Ansible managed - per-model overrides for aider
+# Increase num_ctx from Ollama default (2048) which is too small for code
+- name: {{ aider_model }}
+  extra_params:
+    num_ctx: {{ aider_num_ctx }}


### PR DESCRIPTION
## 概要
aider ロールの設定バグを修正する。

## 問題
`.aider.conf.yml` の `extra-params` に `num_ctx` を書いていたが、aider がこれを CLI 引数としてパースする際に JSON ではなく Python 辞書記法（`{'num_ctx': 32768}`）になり、ファイル名として解釈されて空ファイルが作成される不具合があった。

## 変更内容
- `extra-params` を `.aider.conf.yml` から削除
- `~/.aider.model.settings.yml` を新規追加（aider 公式のモデル別設定ファイル）し、`num_ctx: 32768` をここで設定
- `set-env: [OLLAMA_API_BASE=http://127.0.0.1:11434]` を追加して警告を解消
- `aider_ollama_api_base` 変数を `defaults/main.yml` に追加

## QA 手順
```bash
ansible-playbook .ansible/site.yml -i .ansible/inventory --tags aider
aider  # OLLAMA_API_BASE 警告と空ファイル作成が解消されていることを確認
```