### PR TITLE
feat(claudecode): worktree 跨ぎの承認プロンプトを抑制 (additionalDirectories)

### DIFF
--- a/.ansible/roles/claudecode/templates/settings.json.j2
+++ b/.ansible/roles/claudecode/templates/settings.json.j2
@@ -49,6 +49,9 @@
       "Bash(*> /dev/sd*)",
       "Bash(terraform apply:*)",
       "Bash(terraform destroy:*)"
+    ],
+    "additionalDirectories": [
+      "~/src"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## 概要

`acceptEdits` モードでも CWD 外への Write/Edit が毎回承認プロンプトを出す問題を解消する。

特に worktree を多用していると、worktree A で起動したセッションから worktree B のファイルを編集する際、毎回プロンプトが出てワークフローを阻害していた。

## 変更内容

`roles/claudecode/templates/settings.json.j2` の `permissions` ブロックに `additionalDirectories` を追加し、`~/src` 全体を信頼スコープに含める。

```diff
       "Bash(*> /dev/sd*)",
       "Bash(terraform apply:*)",
       "Bash(terraform destroy:*)"
+    ],
+    "additionalDirectories": [
+      "~/src"
     ]
   },
```

これで `~/src` 配下の全リポジトリ・全 worktree（`~/src/codael/.claude/worktrees/*` 等）への Write/Edit が CWD 関係なく自動承認される。

## QA 手順

1. `cd mac && bash install.sh` で playbook を流す
2. `~/.claude/settings.json` の `permissions.additionalDirectories` に `~/src` が入っていることを確認
3. 任意の worktree で `claude` を起動し、別 worktree のファイルを編集 → 承認プロンプトが出ないことを確認

## 影響範囲

- `~/src` 配下の全リポジトリへの Write/Edit が CWD 外でも自動承認される（信頼境界の拡大）
- `~/src` 外（例: `~/Documents`、`~/.ssh`）は従来通りプロンプトが出る