### PR TITLE
refactor(ollama): remove aider tag

### DIFF
--- a/.ansible/roles/ollama/tasks/main.yml
+++ b/.ansible/roles/ollama/tasks/main.yml
@@ -65,24 +65,20 @@
   ansible.builtin.stat:
     path: "{{ aider_bin_path }}"
   register: aider_bin
-  tags: aider
 
 - name: install aider via official script
   ansible.builtin.shell: "curl -fsSL https://aider.chat/install.sh | sh"
   when: not aider_bin.stat.exists
   changed_when: true
-  tags: aider
 
 - name: copy aider config (~/.aider.conf.yml)
   ansible.builtin.template:
     src: aider.conf.yml.j2
     dest: "{{ ansible_env.HOME }}/.aider.conf.yml"
     mode: 0644
-  tags: aider
 
 - name: copy aider model settings (~/.aider.model.settings.yml)
   ansible.builtin.template:
     src: aider.model.settings.yml.j2
     dest: "{{ ansible_env.HOME }}/.aider.model.settings.yml"
     mode: 0644
-  tags: aider


### PR DESCRIPTION
## 概要
PR #140 で aider を ollama に統合した際、`tags: aider` を残していたが、統合後は不要なため削除する。

## 変更内容
- `roles/ollama/tasks/main.yml` の aider タスクから `tags: aider` を削除

## QA手順
- `--tags ollama` で ollama + aider が両方セットアップされることを確認

## 影響範囲
- `--tags aider` は使用不可になる（`--tags ollama` に集約）