### PR TITLE
fix(opencode): tap sst/tap before installing opencode

### DIFF
--- a/.ansible/roles/opencode/tasks/main.yml
+++ b/.ansible/roles/opencode/tasks/main.yml
@@ -69,6 +69,11 @@
 # ============================================
 - name: setup opencode (macOS)
   block:
+    - name: tap sst/tap
+      community.general.homebrew_tap:
+        name: sst/tap
+        state: present
+
     - name: install opencode
       community.general.homebrew:
         name: sst/tap/opencode


### PR DESCRIPTION
## 概要

PR #143 でマージした opencode ロールが macOS で実行時エラーになるため修正する。

## 変更内容

- `roles/opencode/tasks/main.yml` の macOS ブロックに `community.general.homebrew_tap` で `sst/tap` を登録するタスクを追加

## 背景

Homebrew はサードパーティ tap からインストールする際、事前に tap の登録が必要。

\`\`\`
Error: No available formula or cask with the name "sst/tap/opencode".
This command requires the tap sst/tap.
\`\`\`

## QA手順

- [ ] \`ansible-playbook .ansible/site.yml -i .ansible/inventory --tags opencode\` が成功
- [ ] \`brew list --formula | grep opencode\` で確認
- [ ] \`opencode --version\` でバイナリ確認

## 影響範囲

- macOS のセットアップ（Linux は影響なし）