### PR TITLE
fix: show dotfiles in fzf-lua file and grep search

### DIFF
--- a/.ansible/roles/neovim/templates/init.vim.j2
+++ b/.ansible/roles/neovim/templates/init.vim.j2
@@ -346,8 +346,11 @@ if fzf_lua_ok then
         ["ctrl-a"] = "toggle-all",
       },
     },
+    files = {
+      fd_opts = "--hidden",
+    },
     grep = {
-      rg_opts = "--column --line-number --no-heading --color=always --smart-case",
+      rg_opts = "--column --line-number --no-heading --color=always --smart-case --hidden",
       no_sort = true,
     },
   })


### PR DESCRIPTION
## 概要
fzf-luaのファイル検索(Ctrl+P)とgrep検索(Ctrl+F)で、ドットディレクトリ/ドットファイルが表示されない問題を修正する。

## 変更内容
- `files.fd_opts` に `--hidden` を追加（fdコマンドでドットファイルを対象に）
- `grep.rg_opts` に `--hidden` を追加（ripgrepでドットファイルを対象に）