### PR TITLE
chore: set opencode default model to gemma4 via Ollama

### DIFF
--- a/.ansible/roles/opencode/defaults/main.yml
+++ b/.ansible/roles/opencode/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 ollama_models:
   - gemma4
+
+opencode_default_model: "gemma4"

--- a/.ansible/roles/opencode/tasks/main.yml
+++ b/.ansible/roles/opencode/tasks/main.yml
@@ -92,3 +92,18 @@
       when: not opencode_bin.stat.exists
       changed_when: not opencode_bin.stat.exists
   when: ansible_distribution in ['Ubuntu', 'Debian']
+
+# ============================================
+# opencode config
+# ============================================
+- name: ensure opencode config directory exists
+  ansible.builtin.file:
+    path: "{{ ansible_env.HOME }}/.config/opencode"
+    state: directory
+    mode: "0755"
+
+- name: deploy opencode global config
+  ansible.builtin.template:
+    src: opencode.json.j2
+    dest: "{{ ansible_env.HOME }}/.config/opencode/opencode.json"
+    mode: "0644"

--- a/.ansible/roles/opencode/templates/opencode.json.j2
+++ b/.ansible/roles/opencode/templates/opencode.json.j2
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "ollama/{{ opencode_default_model }}",
+  "autoupdate": true
+}


### PR DESCRIPTION
## 概要
opencodeのデフォルトモデルをローカルのOllama gemma4に設定する。

## 変更内容
- `opencode_default_model` 変数を追加（デフォルト: gemma4）
- opencodeのグローバル設定（`~/.config/opencode/opencode.json`）をAnsibleで管理
- デフォルトモデルを `ollama/gemma4` に設定