### PR TITLE
chore: set opencode default model to llama3.3 via Ollama

### DIFF
--- a/.ansible/roles/opencode/defaults/main.yml
+++ b/.ansible/roles/opencode/defaults/main.yml
@@ -1,5 +1,7 @@
 ---
+# Ollama で pull するモデル一覧
 ollama_models:
-  - gemma4
+  - llama3.3
 
-opencode_default_model: "gemma4"
+# opencode のデフォルトモデル（ollama_models に含まれている必要がある）
+opencode_default_model: "llama3.3"


### PR DESCRIPTION
## 概要
opencode のデフォルトモデルを `gemma4` から `llama3.3` に変更する。

## 変更内容
- `.ansible/roles/opencode/defaults/main.yml`
  - `ollama_models` を `gemma4` → `llama3.3` に変更
  - `opencode_default_model` を `gemma4` → `llama3.3` に変更
  - 既存スタイルに合わせてコメントを追加

## QA手順
1. `ansible-playbook .ansible/site.yml -i .ansible/inventory --tags opencode` を実行
2. `ollama list` で `llama3.3` が pull されていることを確認
3. `~/.config/opencode/opencode.json` の `model` が `ollama/llama3.3` になっていることを確認
4. `opencode` を起動し、Llama 3.3 で応答が返ることを確認

## 影響範囲
- opencode のデフォルトモデル選択のみ
- 既存の `gemma4` モデルは ollama 内に残るため、不要なら `ollama rm gemma4` で手動削除可