### PR TITLE
chore: switch opencode default model to llama3.1:8b

### DIFF
--- a/.ansible/roles/opencode/defaults/main.yml
+++ b/.ansible/roles/opencode/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Ollama で pull するモデル一覧
 ollama_models:
-  - llama3.3
+  - "llama3.1:8b"
 
 # opencode のデフォルトモデル（ollama_models に含まれている必要がある）
-opencode_default_model: "llama3.3"
+opencode_default_model: "llama3.1:8b"


### PR DESCRIPTION
## 概要
opencode のデフォルトモデルを `llama3.3` から `llama3.1:8b` に変更する。

`llama3.3` (約 43GB) はディスク空き容量に対して大きすぎ pull が完走しなかったため、より軽量で gemma4 と同程度のサイズである `llama3.1:8b` (約 4.7GB) に切り替える。

## 変更内容
- `.ansible/roles/opencode/defaults/main.yml`
  - `ollama_models` を `llama3.3` → `"llama3.1:8b"` に変更
  - `opencode_default_model` を `llama3.3` → `llama3.1:8b` に変更

## QA手順
1. `ansible-playbook .ansible/site.yml -i .ansible/inventory --tags opencode` を実行
2. `ollama list` で `llama3.1:8b` が pull されていることを確認
3. `~/.config/opencode/opencode.json` の `model` が `ollama/llama3.1:8b` になっていることを確認
4. `opencode` を起動し、応答が返ることを確認

## 影響範囲
- opencode のデフォルトモデル選択のみ