### PR TITLE
feat(opencode): manage model state file via Ansible

### DIFF
--- a/.ansible/roles/opencode/tasks/main.yml
+++ b/.ansible/roles/opencode/tasks/main.yml
@@ -107,3 +107,17 @@
     src: opencode.json.j2
     dest: "{{ ansible_env.HOME }}/.config/opencode/opencode.json"
     mode: "0644"
+
+- name: ensure opencode state directory exists
+  ansible.builtin.file:
+    path: "{{ ansible_env.HOME }}/.local/state/opencode"
+    state: directory
+    mode: "0755"
+
+# このファイルは playbook 実行ごとに上書きされる。
+# TUI 内で /model 切替しても、次回 playbook 実行時に opencode_default_model に戻る。
+- name: deploy opencode model state
+  ansible.builtin.template:
+    src: model.json.j2
+    dest: "{{ ansible_env.HOME }}/.local/state/opencode/model.json"
+    mode: "0644"

--- a/.ansible/roles/opencode/templates/model.json.j2
+++ b/.ansible/roles/opencode/templates/model.json.j2
@@ -1,0 +1,7 @@
+{
+  "recent": [],
+  "favorite": [],
+  "variant": {
+    "ollama/{{ opencode_default_model }}": "default"
+  }
+}


### PR DESCRIPTION
## 概要
opencode の状態ファイル `~/.local/state/opencode/model.json` を Ansible で管理する。

opencode は新規セッションのデフォルトモデル選択に opencode.json の `model` ではなく、state ファイルの `variant` エントリを優先する。これまで TUI で過去に選択したモデル（`opencode/big-pickle` 等）が残ると、playbook で `opencode_default_model` を変更してもデフォルトが切り替わらなかったため、state ファイルも playbook で上書き管理する。

## 変更内容
- `.ansible/roles/opencode/templates/model.json.j2` 新規作成
  - `variant` に `ollama/{{ opencode_default_model }}: "default"` のみを設定
- `.ansible/roles/opencode/tasks/main.yml` に2タスク追加
  - state ディレクトリ作成
  - `model.json` テンプレート配置（毎回上書き）

## QA手順
1. `ansible-playbook .ansible/site.yml -i .ansible/inventory --tags opencode` を実行
2. `cat ~/.local/state/opencode/model.json` で variant が `ollama/llama3.1:8b: "default"` のみになっていることを確認
3. `opencode` を起動し、デフォルトモデルが `ollama/llama3.1:8b` になっていることを確認

## 影響範囲
- opencode の state ファイルが playbook 実行ごとに上書きされる（TUI 内 `/model` で切替しても次回 playbook で巻き戻る）
- 上記挙動はタスク直前のコメントにも記載