### PR TITLE
feat(opencode): register ollama as a provider

### DIFF
--- a/.ansible/roles/opencode/tasks/main.yml
+++ b/.ansible/roles/opencode/tasks/main.yml
@@ -107,17 +107,3 @@
     src: opencode.json.j2
     dest: "{{ ansible_env.HOME }}/.config/opencode/opencode.json"
     mode: "0644"
-
-- name: ensure opencode state directory exists
-  ansible.builtin.file:
-    path: "{{ ansible_env.HOME }}/.local/state/opencode"
-    state: directory
-    mode: "0755"
-
-# このファイルは playbook 実行ごとに上書きされる。
-# TUI 内で /model 切替しても、次回 playbook 実行時に opencode_default_model に戻る。
-- name: deploy opencode model state
-  ansible.builtin.template:
-    src: model.json.j2
-    dest: "{{ ansible_env.HOME }}/.local/state/opencode/model.json"
-    mode: "0644"

--- a/.ansible/roles/opencode/templates/model.json.j2
+++ b/.ansible/roles/opencode/templates/model.json.j2
@@ -1,7 +1,0 @@
-{
-  "recent": [],
-  "favorite": [],
-  "variant": {
-    "ollama/{{ opencode_default_model }}": "default"
-  }
-}

--- a/.ansible/roles/opencode/templates/opencode.json.j2
+++ b/.ansible/roles/opencode/templates/opencode.json.j2
@@ -1,5 +1,17 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "model": "ollama/{{ opencode_default_model }}",
+  "provider": {
+    "ollama": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Ollama (local)",
+      "options": {
+        "baseURL": "http://localhost:11434/v1"
+      },
+      "models": {
+{% for m in ollama_models %}        "{{ m }}": { "name": "{{ m }}" }{% if not loop.last %},{% endif %}
+{% endfor %}      }
+    }
+  },
   "autoupdate": true
 }


### PR DESCRIPTION
## 概要
opencode が ollama を自動認識せず、デフォルトモデルが意図せず opencode 提供モデル（big-pickle 等）にフォールバックしていた問題を修正する。`opencode.json` に明示的な ollama プロバイダ定義を追加し、PR #150 で追加した state ファイル管理（実効果なし）を撤回する。

## 背景
- opencode は `models.dev` の providers リストから provider を解決するが、`ollama` はそのリストに含まれない
- そのため `model: "ollama/llama3.1:8b"` だけでは解決できず opencode 自前のモデル（`opencode/big-pickle`）が選択されていた
- PR #150 で `~/.local/state/opencode/model.json` の variant マップを上書きする対策を入れたが、これは active model を制御していなかったため効果なし

## 変更内容
- `templates/opencode.json.j2`: `provider.ollama` ブロックを追加
  - npm: `@ai-sdk/openai-compatible`
  - baseURL: `http://localhost:11434/v1`
  - models は `ollama_models` をループ展開（既存テンプレートのループ記法に合わせる）
- `templates/model.json.j2`: 削除
- `tasks/main.yml`: state ディレクトリ作成と model.json テンプレート配置の2タスクを削除

## QA手順
1. `ansible-playbook .ansible/site.yml -i .ansible/inventory --tags opencode` を実行
2. `opencode debug config` で `provider.ollama` が出力に含まれることを確認
3. `opencode models | grep ollama` で `ollama/llama3.1:8b` が表示されることを確認
4. `opencode` を起動し、デフォルトモデルが `Ollama (local) / llama3.1:8b` になっていることを確認

## 影響範囲
- opencode のモデル解決のみ。Ollama サービスや ansible 他ロールへの影響なし