### PR TITLE
chore(opencode): switch default LLM from llama3.1:8b to qwen2.5-coder:7b

### DIFF
--- a/.ansible/roles/opencode/defaults/main.yml
+++ b/.ansible/roles/opencode/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Ollama で pull するモデル一覧
 ollama_models:
-  - "llama3.1:8b"
+  - "qwen2.5-coder:7b"
 
 # opencode のデフォルトモデル（ollama_models に含まれている必要がある）
-opencode_default_model: "llama3.1:8b"
+opencode_default_model: "qwen2.5-coder:7b"


### PR DESCRIPTION
## 概要
opencode で使用するローカル LLM を `llama3.1:8b` から `qwen2.5-coder:7b` に変更する。
llama3.1:8b は指示追従が弱くコーディング用途で使いづらいため、コーディング特化で
指示追従が強い qwen2.5-coder:7b に切り替える。

## 変更内容
- `roles/opencode/defaults/main.yml` の `ollama_models` を `qwen2.5-coder:7b` に変更
- `opencode_default_model` を `qwen2.5-coder:7b` に変更

## QA手順
1. `ansible-playbook .ansible/site.yml -i .ansible/inventory --tags opencode` を実行
2. `ollama list` で `qwen2.5-coder:7b` が pull されていることを確認
3. `~/.config/opencode/opencode.json` の default model が `qwen2.5-coder:7b` になっていることを確認
4. opencode 起動 → 指示追従が改善されているか動作確認

## 影響範囲
- opencode のデフォルトモデル
- 旧モデル（llama3.1:8b）は手動で `ollama rm llama3.1:8b` で削除可能