### PR TITLE
chore(claudecode): bump Claude Code version to 2.1.144

### DIFF
--- a/.ansible/roles/claudecode/defaults/main.yml
+++ b/.ansible/roles/claudecode/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Claude Code 設定
 
-claude_code_version: "2.1.138"
+claude_code_version: "2.1.144"
 
 # Claude Code directories
 claudecode_dir:


### PR DESCRIPTION
## 概要
Claude Code のバージョンを最新版に追従する。

## 変更内容
- `.ansible/roles/claudecode/defaults/main.yml` の `claude_code_version` を `2.1.138` → `2.1.144` に更新

## QA手順
- `ansible-playbook .ansible/site.yml -i .ansible/inventory --tags claudecode` を実行
- `claude --version` が `2.1.144` を返すことを確認

## 影響範囲
- Claude Code CLI のみ
