### PR TITLE
chore(claudecode): bump Claude Code version to 2.1.168

### DIFF
--- a/.ansible/roles/claudecode/defaults/main.yml
+++ b/.ansible/roles/claudecode/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Claude Code 設定
 
-claude_code_version: "2.1.156"
+claude_code_version: "2.1.168"
 
 # Claude Code directories
 claudecode_dir:

--- a/.ansible/roles/claudecode/defaults/main.yml
+++ b/.ansible/roles/claudecode/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Claude Code 設定
 
-claude_code_version: "2.1.144"
+claude_code_version: "2.1.156"
 
 # Claude Code directories
 claudecode_dir:


### PR DESCRIPTION
## 概要
Claude Code CLI のバージョンを Native installer の latest（2.1.168）に更新する。

## 変更内容
- `.ansible/roles/claudecode/defaults/main.yml` の `claude_code_version` を `2.1.144` → `2.1.168` に更新

## QA手順
1. `cd mac && bash install.sh` または `ansible-playbook .ansible/site.yml -i .ansible/inventory --tags claudecode` を実行
2. `claude --version` で `2.1.168` が表示されることを確認

## 影響範囲
- ローカル環境にインストールされる Claude Code CLI のバージョンのみ
